### PR TITLE
Add support for MathJax. 

### DIFF
--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -15,6 +15,27 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
       link rel='stylesheet' href=(attr :revealjs_customtheme) id='theme'
     - else
       link rel='stylesheet' href='reveal.js/css/theme/default.css' id='theme'
+    - if attr? :stem
+      - asset_uri_scheme = (attr 'asset-uri-scheme', 'https')
+      - asset_uri_scheme = %(#{asset_uri_scheme}:) unless asset_uri_scheme.empty?
+      - cdn_base = %(#{asset_uri_scheme}//cdnjs.cloudflare.com/ajax/libs)
+      - eqnums_val = (attr 'eqnums', 'none')
+      - eqnums_val = 'AMS' if eqnums_val == ''
+      - eqnums_opt = %( equationNumbers: { autoNumber: "#{eqnums_val}" } )
+      script type='text/x-mathjax-config'
+        | MathJax.Hub.Config({
+          tex2jax: {
+            inlineMath: [#{Asciidoctor::INLINE_MATH_DELIMITERS[:latexmath].to_s}],
+            displayMath: [#{Asciidoctor::BLOCK_MATH_DELIMITERS[:latexmath].to_s}],
+            ignoreClass: "nostem|nolatexmath"
+          },
+          asciimath2jax: {
+            delimiters: [#{Asciidoctor::BLOCK_MATH_DELIMITERS[:asciimath].to_s}],
+            ignoreClass: "nostem|noasciimath"
+          },
+          TeX: {#{eqnums_opt}}
+          });
+      script src='#{cdn_base}/mathjax/2.4.0/MathJax.js?config=TeX-MML-AM_HTMLorMML'  
     - case attr 'source-highlighter'
     - when 'coderay'
       - if (attr 'coderay-css', 'class') == 'class'


### PR DESCRIPTION
Load MathJax.js if document contains :stem: attribute.

Sidenote: 
  Only thing that I am not so happy with is that the code is nearly a copy of the part in the html5 backend, except for translating plain ruby to slim. If integration of MathJax changes one day both converters have to be touched.
