### PR TITLE
Adding ability to change reveal.js path

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -181,6 +181,10 @@ Default settings are based on `reveal.js` default settings.
 |<file\|URL>
 | Overrides CSS with given file or URL. Default is disabled.
 
+|:revealjsdir:
+|<file\|URL>
+| Overrides reveal.js directory. Example : ../reveal.js
+
 |:revealjs_controls:
 |*true*, false
 |Display controls in the bottom right corner.

--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -7,7 +7,6 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
       - if attr? key
         meta name=key content=(attr key)
     title=(doctitle sanitize: true, use_fallback: true)
-    meta perso="#{revealjsdir}" test="#{attr :revealjsdir}" test2="#{attr 'revealjsdir'}"
     meta content="yes" name="apple-mobile-web-app-capable"
     meta content="black-translucent" name="apple-mobile-web-app-status-bar-style"
     meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui" name="viewport"

--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -2,19 +2,21 @@ doctype 5
 html lang=(attr :lang, 'en' unless attr? :nolang)
   head
     meta charset="utf-8"
+    - revealjsdir = (attr :revealjsdir, 'reveal.js')
     - [:description, :keywords, :author, :copyright].each do |key|
       - if attr? key
         meta name=key content=(attr key)
     title=(doctitle sanitize: true, use_fallback: true)
+    meta perso="#{revealjsdir}" test="#{attr :revealjsdir}" test2="#{attr 'revealjsdir'}"
     meta content="yes" name="apple-mobile-web-app-capable"
     meta content="black-translucent" name="apple-mobile-web-app-status-bar-style"
     meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui" name="viewport"
-    link href="reveal.js/css/reveal.min.css" rel="stylesheet"
+    link href="#{revealjsdir}/css/reveal.min.css" rel="stylesheet"
     / Default theme required even when using custom theme
     - if attr? :revealjs_customtheme
       link rel='stylesheet' href=(attr :revealjs_customtheme) id='theme'
     - else
-      link rel='stylesheet' href='reveal.js/css/theme/default.css' id='theme'
+      link rel='stylesheet' href='#{revealjsdir}/css/theme/default.css' id='theme'
     - if attr? :stem
       - asset_uri_scheme = (attr 'asset-uri-scheme', 'https')
       - asset_uri_scheme = %(#{asset_uri_scheme}:) unless asset_uri_scheme.empty?
@@ -50,10 +52,10 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         - else
           style=Asciidoctor::Stylesheets.instance.pygments_stylesheet_data(attr 'pygments-style')
     / For syntax highlighting
-    link href="reveal.js/lib/css/zenburn.css" rel="stylesheet"
+    link href="#{revealjsdir}/lib/css/zenburn.css" rel="stylesheet"
     / If the query includes 'print-pdf', use the PDF print sheet
     javascript:
-      document.write( '<link rel="stylesheet" href="reveal.js/css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
+      document.write( '<link rel="stylesheet" href="#{revealjsdir}/css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
     - unless (docinfo_content = docinfo :header, '.html').empty?
       =docinfo_content
   body
@@ -65,8 +67,8 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
             h2=@header.title
             p: small=author
         =content
-    script src="reveal.js/lib/js/head.min.js"
-    script src="reveal.js/js/reveal.min.js"
+    script src="#{revealjsdir}/lib/js/head.min.js"
+    script src="#{revealjsdir}/js/reveal.min.js"
     javascript:
       // See https://github.com/hakimel/reveal.js#configuration for a full list of configuration options
       Reveal.initialize({
@@ -123,12 +125,12 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         parallaxBackgroundSize: '#{attr 'revealjs_parallaxbackgroundsize', ''}',
         // Optional libraries used to extend on reveal.js
         dependencies: [
-            { src: 'reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
-            { src: 'reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-            { src: 'reveal.js/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-            #{(attr? 'source-highlighter', 'highlight.js') ? "{ src: 'reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }," : nil}
-            { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
-            { src: 'reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
+            { src: '#{revealjsdir}/lib/js/classList.js', condition: function() { return !document.body.classList; } },
+            { src: '#{revealjsdir}/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+            { src: '#{revealjsdir}/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+            #{(attr? 'source-highlighter', 'highlight.js') ? "{ src: '#{revealjsdir}/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }," : nil}
+            { src: '#{revealjsdir}/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
+            { src: '#{revealjsdir}/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
         ]
       });
     - unless (docinfo_content = (docinfo :footer, '.html')).empty?


### PR DESCRIPTION
When generating more than one document it should be nice to be able pointing the same folder.
Actually, the reveal.js dir is hardcoded in the document.html.slim and the folder has to be copied in each presentation folder..

addition of a revealjsdir attribute to specify the location of the reveal.js folder.
Based on the work of @dsyer for deckJs asciidoctor/asciidoctor-backends@1b28d98