### PR TITLE
Upgrade to reveal 3.0.0

### DIFF
--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -10,12 +10,12 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
     meta content="yes" name="apple-mobile-web-app-capable"
     meta content="black-translucent" name="apple-mobile-web-app-status-bar-style"
     meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui" name="viewport"
-    link href="#{revealjsdir}/css/reveal.min.css" rel="stylesheet"
+    link href="#{revealjsdir}/css/reveal.css" rel="stylesheet"
     / Default theme required even when using custom theme
     - if attr? :revealjs_customtheme
       link rel='stylesheet' href=(attr :revealjs_customtheme) id='theme'
     - else
-      link rel='stylesheet' href='#{revealjsdir}/css/theme/default.css' id='theme'
+      link rel='stylesheet' href='#{revealjsdir}/css/theme/black.css' id='theme'
     - if attr? :stem
       - asset_uri_scheme = (attr 'asset-uri-scheme', 'https')
       - asset_uri_scheme = %(#{asset_uri_scheme}:) unless asset_uri_scheme.empty?
@@ -36,7 +36,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
           },
           TeX: {#{eqnums_opt}}
           });
-      script src='#{cdn_base}/mathjax/2.4.0/MathJax.js?config=TeX-MML-AM_HTMLorMML'  
+      script src='#{cdn_base}/mathjax/2.4.0/MathJax.js?config=TeX-MML-AM_HTMLorMML'
     - case attr 'source-highlighter'
     - when 'coderay'
       - if (attr 'coderay-css', 'class') == 'class'
@@ -67,7 +67,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
             p: small=author
         =content
     script src="#{revealjsdir}/lib/js/head.min.js"
-    script src="#{revealjsdir}/js/reveal.min.js"
+    script src="#{revealjsdir}/js/reveal.js"
     javascript:
       // See https://github.com/hakimel/reveal.js#configuration for a full list of configuration options
       Reveal.initialize({
@@ -108,13 +108,13 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         hideAddressBar: #{attr 'revealjs_hideaddressbar', 'true'},
         // Opens links in an iframe preview overlay
         previewLinks: #{attr 'revealjs_previewlinks', 'false'},
-        // Theme (e.g., beige, blond, default, moon, night, serif, simple, sky, solarized)
+        // Theme (e.g., beige, black, blood, league, moon, night, serif, simple, sky, solarized, white)
         theme: Reveal.getQueryHash().theme || '#{attr 'revealjs_theme', 'default'}',
-        // Transition style (e.g., default, cube, page, concave, zoom, linear, fade, none)
+        // Transition style (e.g., none, fade, slide, convex, concave, zoom)
         transition: Reveal.getQueryHash().transition || '#{attr 'revealjs_transition', 'default'}',
         // Transition speed (e.g., default, fast, slow)
         transitionSpeed: '#{attr 'revealjs_transitionspeed', 'default'}',
-        // Transition style for full page slide backgrounds (e.g., default, none, slide, concave, convex, zoom)
+        // Transition style for full page slide backgrounds (e.g., none, fade, slide, convex, concave, zoom)
         backgroundTransition: '#{attr 'revealjs_backgroundtransition', 'default'}',
         // Number of slides away from the current that are visible
         viewDistance: #{attr 'revealjs_viewdistance', 3},
@@ -129,7 +129,8 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
             { src: '#{revealjsdir}/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
             #{(attr? 'source-highlighter', 'highlight.js') ? "{ src: '#{revealjsdir}/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }," : nil}
             { src: '#{revealjsdir}/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
-            { src: '#{revealjsdir}/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
+            { src: '#{revealjsdir}/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } },
+            { src: '#{revealjsdir}/plugin/math/math.js', async: true}
         ]
       });
     - unless (docinfo_content = (docinfo :footer, '.html')).empty?


### PR DESCRIPTION
Use https://github.com/hakimel/reveal.js/releases/tag/3.0.0 as a guide

As of 3.0.0 they excluding minified files from the distributed release artifact. If we want minification we'll have to do it ourselves.

Other than a few minor changes this was straightforward.