### PR TITLE
Make used highlight style configurable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -181,6 +181,10 @@ Default settings are based on `reveal.js` default settings.
 |<file\|URL>
 | Overrides CSS with given file or URL. Default is disabled.
 
+|:highlightjs_style:
+|<file\|URL>
+| Overrides https://highlightjs.org[highlight.js] CSS style with given file or URL. Default is disabled.
+
 |:revealjsdir:
 |<file\|URL>
 | Overrides reveal.js directory. Example : ../reveal.js
@@ -283,4 +287,4 @@ This value can be overwritten by using a `data-autoslide` attribute on your slid
 
 |===
 
-If you want to build a custom theme or customize an existing one you should look at the https://github.com/asciidoctor/asciidoctor-maven-examples/blob/master/asciidoc-to-pdf-example/pom.xml[reveal.js documentation] and use `revealjs_theme` AsciiDoc attribute to activate it.
+If you want to build a custom theme or customize an existing one you should look at the https://github.com/hakimel/reveal.js/blob/master/css/theme/README.md[reveal.js documentation] and use `revealjs_customtheme` AsciiDoc attribute to activate it.

--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -51,7 +51,10 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         - else
           style=Asciidoctor::Stylesheets.instance.pygments_stylesheet_data(attr 'pygments-style')
     / For syntax highlighting
-    link href="#{revealjsdir}/lib/css/zenburn.css" rel="stylesheet"
+    - if attr? :highlightjs_style
+      link href=(attr :highlightjs_style) rel="stylesheet"
+    - else
+      link href="#{revealjsdir}/lib/css/zenburn.css" rel="stylesheet"
     / If the query includes 'print-pdf', use the PDF print sheet
     javascript:
       document.write( '<link rel="stylesheet" href="#{revealjsdir}/css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );


### PR DESCRIPTION
By default, the 'zenburn' syntax highlighting style from highlight.js
is included with reveal.js and used. But now you can provide
your own path|URL to a custom syntax highlighing style.
eg. one of the many other styles highlight.js offers.

Also corrected the link to the reveal.js theme edit/creation documentation