### PR TITLE
Added width / scale / margins options

### DIFF
--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -131,6 +131,20 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         parallaxBackgroundImage: '#{attr 'revealjs_parallaxbackgroundimage', ''}',
         // Parallax background size in CSS syntax (e.g., "2100px 900px")
         parallaxBackgroundSize: '#{attr 'revealjs_parallaxbackgroundsize', ''}',
+        
+        // The "normal" size of the presentation, aspect ratio will be preserved
+        // when the presentation is scaled to fit different resolutions. Can be
+        // specified using percentage units.
+        width: #{attr 'revealjs_width', 960},
+        height: #{attr 'revealjs_height', 700},
+
+        // Factor of the display size that should remain empty around the content
+        margin: #{attr 'revealjs_margin', 0.1},
+
+        // Bounds for smallest/largest possible scale to apply to content
+        minScale: #{attr 'revealjs_minscale', 0.2},
+        maxScale: #{attr 'revealjs_maxscale', 1.5},
+        
         // Optional libraries used to extend on reveal.js
         dependencies: [
             { src: '#{revealjsdir}/lib/js/classList.js', condition: function() { return !document.body.classList; } },


### PR DESCRIPTION
Fixes #26. The changes are pretty straightforward, and follow the convention above of defaulting to the reveal.js defaults.

I didn't add any testing because I don't really know how to do automated testing of something like this, but I did make some slides where I used these features and it worked for me. 