### PR TITLE
Drop the data- prefix on the slide attributes

### DIFF
--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -2,7 +2,7 @@
 - hide_title = (title = self.title) == '!'
 - if @level == 1 && !(subsections = sections).empty?
   section
-    section id=(hide_title ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
+    section id=(hide_title ? nil : @id) data-transition=(attr 'transition') data-transition-speed=(attr 'transition-speed') data-background=(attr 'background') data-background-size=(attr 'background-size') data-background-repeat=(attr 'background-repeat') data-background-transition=(attr 'background-transition')
       - unless hide_title
         h2=title
       - (blocks - subsections).each do |block|
@@ -11,7 +11,7 @@
       =subsection.convert
 / standalone slides
 - else
-  section id=(hide_title ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
+  section id=(hide_title ? nil : @id) data-transition=(attr 'transition') data-transition-speed=(attr 'transition-speed') data-background=(attr 'background') data-background-size=(attr 'background-size') data-background-repeat=(attr 'background-repeat') data-background-transition=(attr 'background-transition')
     - unless hide_title
       h2=title
     =content.chomp


### PR DESCRIPTION
Copy and pasting from #18 

> Reveal.js recognizes a handful of data attributes (attributes with the prefix data-) for setting the background properties of a slide. Currently, the Asciidoctor section template passes these attributes through verbatim. I don't think we need the data- prefix and therefore propose to drop it.
>
>  The data- prefix is required in the HTML as a namespace. We don't need this prefix in the AsciiDoc document as it doesn't add any semantic value nor is is required for compliance.

I also removed the prefix for the `transition` attribute.

I am not too familiar with asciidoctor templates. Is this all it takes?
