### PR TITLE
document preamble shown only on title slide (fixes #49, #43)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -287,3 +287,7 @@ Defaults to none
 |===
 
 If you want to build a custom theme or customize an existing one you should look at the https://github.com/hakimel/reveal.js/blob/master/css/theme/README.md[reveal.js documentation] and use the `revealjs_customtheme` AsciiDoc attribute to activate it.
+
+== Minimum Requirements
+
+* asciidoctor 1.5.0

--- a/templates/slim/block_preamble.html.slim
+++ b/templates/slim/block_preamble.html.slim
@@ -1,0 +1,2 @@
+/ file intentionally left blank
+/ preamble is shown on the title slide which is rendered by document template

--- a/templates/slim/block_preamble.html.slim
+++ b/templates/slim/block_preamble.html.slim
@@ -1,6 +1,0 @@
-#preamble
-  .sectionbody=content
-  - if (attr? :toc) && (attr? 'toc-placement', 'preamble')
-    #toc class=(attr 'toc-class', 'toc')
-      #toctitle=(attr 'toc-title')
-      =Asciidoctor::HTML5::DocumentTemplate.outline(@document, (attr :toclevels, 2).to_i)

--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -72,6 +72,9 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         - unless notitle || !has_header?
           section
             h2=@header.title
+            - preamble = @document.find_by context: :preamble
+            - if preamble.length > 0
+              =preamble.pop.content
             p: small=author
         =content
     script src="#{revealjsdir}/lib/js/head.min.js"


### PR DESCRIPTION
As discussed in #49. Thanks for the guidance @mojavelinux. 

`@document.find_by` doesn't work on asciidoctor previous to 1.5.0 so I thought I mentioned minimum requirements in the README.