### PR TITLE
Footers for Reveal.js Slides

### DIFF
--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -69,6 +69,9 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
       link rel='stylesheet' href=((customcss = attr :customcss).empty? ? 'asciidoctor-revealjs.css' : customcss)
   body
     .reveal
+      - unless (docinfo_content = (docinfo :footer, '.html')).empty?
+        .footer style='position: absolute; bottom: 1em; left: 1em'
+          =docinfo_content
       / Any section element inside of this container is displayed as a slide
       .slides
         - unless notitle || !has_header?
@@ -157,7 +160,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         parallaxBackgroundImage: '#{attr 'revealjs_parallaxbackgroundimage', ''}',
         // Parallax background size in CSS syntax (e.g., "2100px 900px")
         parallaxBackgroundSize: '#{attr 'revealjs_parallaxbackgroundsize', ''}',
-        
+
         // The "normal" size of the presentation, aspect ratio will be preserved
         // when the presentation is scaled to fit different resolutions. Can be
         // specified using percentage units.
@@ -170,7 +173,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         // Bounds for smallest/largest possible scale to apply to content
         minScale: #{attr 'revealjs_minscale', 0.2},
         maxScale: #{attr 'revealjs_maxscale', 1.5},
-        
+
         // Optional libraries used to extend on reveal.js
         dependencies: [
             { src: '#{revealjsdir}/lib/js/classList.js', condition: function() { return !document.body.classList; } },
@@ -181,5 +184,3 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
             { src: '#{revealjsdir}/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
         ]
       });
-    - unless (docinfo_content = (docinfo :footer, '.html')).empty?
-      =docinfo_content

--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -68,10 +68,10 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
     - if attr? :customcss
       link rel='stylesheet' href=((customcss = attr :customcss).empty? ? 'asciidoctor-revealjs.css' : customcss)
   body
+    - unless (docinfo_content = (docinfo :footer, '.html')).empty?
+      .footer style='position: absolute; bottom: 5px; left: 1em'
+      =docinfo_content
     .reveal
-      - unless (docinfo_content = (docinfo :footer, '.html')).empty?
-        .footer style='position: absolute; bottom: 1em; left: 1em'
-          =docinfo_content
       / Any section element inside of this container is displayed as a slide
       .slides
         - unless notitle || !has_header?

--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -70,7 +70,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
   body
     - unless (docinfo_content = (docinfo :footer, '.html')).empty?
       .footer style='position: absolute; bottom: 5px; left: 1em'
-      =docinfo_content
+      	=docinfo_content
     .reveal
       / Any section element inside of this container is displayed as a slide
       .slides


### PR DESCRIPTION
Instead of pushing the footer rigt at the end as is the case with normal HTML pages, we sneak it in just at the begining of the Reveal block at the lock the div to the bottom of the page. This allows for the docinfo.html and docinfo-footer.html to be used to easily insert a footer.

All you need to do is to add some content in to the `docinfo-footer.html` file i.e.

```
Use arrows to navigate left and right
```

and at some CSS in `docinto.html` that operates on `div.footer` i.e.

```
<style>
    div.footer {
        font-size: 0.5em;
    }
</style>
```

If `:docinfo`:` is set the asciidoc files, then the footer will appear on each slide.

_Caveats_:  Curretnly the footer is not yet added to the print-pdf functionality. However once people look at this, someone else might figure it out before me how to complete that step.
