### PR TITLE
Add data-state to slides

### DIFF
--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -2,7 +2,7 @@
 - hide_title = (title = self.title) == '!'
 - if @level == 1 && !(subsections = sections).empty?
   section
-    section id=(hide_title ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
+    section id=(hide_title ? nil : @id) data-state=(attr 'data-state') data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
       - unless hide_title
         h2=title
       - (blocks - subsections).each do |block|
@@ -11,7 +11,7 @@
       =subsection.convert
 / standalone slides
 - else
-  section id=(hide_title ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
+  section id=(hide_title ? nil : @id) data-state=(attr 'data-state') data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
     - unless hide_title
       h2=title
     =content.chomp


### PR DESCRIPTION
Reveal.js has the concept of [slide states](https://github.com/hakimel/reveal.js/#slide-states), where a slide's value for `data-state` will be applied to the document as a CSS class. With this it is easy to, e.g. give selected slides a distinct style.

The reaveal.js backend does currently not set the state. With the change proposed here, the following works:

```
[data-state="empty"]
=== !
```

Which leads to 

```
<section data-state="empty" class="present"></section>
```

I did not thoroughly check whether this change should also be applied to one of the other templates.