### PR TITLE
Hide slide titles: support %notitle and %conceal section options (#20)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -163,13 +163,21 @@ Slide Six uses the vertical slide feature of `reveal.js`.
 Slide Six.One will be rendered vertically below Slide Six.
 Here is https://github.com/hakimel/reveal.js#markup[upstream documentation] on that topic.
 
+=== Slides without titles
 
-....
-== !
-This is a slide with hidden title
-....
+There are a few ways to have no titles on slides.
 
-If you don't want to have a title on each of your slides, setting your title to `!` allows you to hide the title of the given slide.
+* Setting your title to `!`
+* Adding the `notitle` option to your slide
+* Adding the `conceal` option to your slide
+
+Here is an example of the three techniques in action:
+
+----
+include::test/concealed-slide-titles.adoc[]
+----
+
+NOTE: `conceal` and `notitle` have the advantage that the slide still has an id so it can be linked to.
 
 == reveal.js Options
 

--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -1,10 +1,12 @@
-- hide_title = (title = self.title) == '!'
+/ hide slides on %conceal, %notitle and named "!"
+- titleless = (title = self.title) == '!'
+- hide_title = (titleless || (option? :notitle) || (option? :conceal))
 - vertical_slides = find_by(context: :section) {|section| section.level == 2 }
 
 / render parent section of vertical slides set
 - if @level == 1 && !vertical_slides.empty?
   section
-    section id=(hide_title ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
+    section id=(titleless ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
       - unless hide_title
         h2=title
       - (blocks - vertical_slides).each do |block|
@@ -19,7 +21,7 @@
     *{tag: %(h#{@level})} =title
     =content.chomp
   - else
-    section id=(hide_title ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
+    section id=(titleless ? nil : @id) data-transition=(attr 'data-transition') data-transition-speed=(attr 'data-transition-speed') data-background=(attr 'data-background') data-background-size=(attr 'data-background-size') data-background-repeat=(attr 'data-background-repeat') data-background-transition=(attr 'data-background-transition')
       - unless hide_title
         h2=title
       =content.chomp

--- a/test/concealed-slide-titles.adoc
+++ b/test/concealed-slide-titles.adoc
@@ -1,0 +1,15 @@
+= Concealed Slide Titles
+
+== !
+
+This
+
+[%notitle]
+== Presentation
+
+presentation's titles
+
+[%conceal]
+== Concealed
+
+should be concealed


### PR DESCRIPTION
Simple fix for issue #20. Thanks to @kubamarchwicki for solution example.