### PR TITLE
Small remarks about gems

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ The https://github.com/asciidoctor/asciidoctor-reveal.js[reveal.js backend] is a
 
 == Prerequisites
 
-. Ensure Asciidoctor, Slim and their dependencies are installed:
+. Ensure Asciidoctor, Slim and their dependencies are installed (in their latest version):
 
   $ gem install asciidoctor tilt thread_safe slim
 

--- a/README.adoc
+++ b/README.adoc
@@ -313,4 +313,4 @@ If you want to build a custom theme or customize an existing one you should look
 
 == Minimum Requirements
 
-* asciidoctor 1.5.0
+* asciidoctor 1.5.4


### PR DESCRIPTION
The latest asciidoctor-reveal.js backend didn't work with asciidoctor-1.5.3 and titl 2.0.1 - which i used to have installed

This is a small but pesky one related to this exact comment: https://github.com/asciidoctor/asciidoctor-reveal.js/pull/52/commits/83a1097086516d6e84cad6abab3bfcb47f3358e2#r56757487 :)