### PR TITLE
chore(licence): MIT license made more explicit

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,0 +1,19 @@
+.The MIT License
+....
+Copyright (C) 2012-2016 Dan Allen and the Asciidoctor Project
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+....

--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,6 +1,7 @@
 .The MIT License
 ....
-Copyright (C) 2012-2016 Dan Allen and the Asciidoctor Project
+Copyright (C) 2012-2016 Olivier Bilodeau, Charles Moulliard, Dan Allen and the
+Asciidoctor Project
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.adoc
+++ b/README.adoc
@@ -314,3 +314,10 @@ If you want to build a custom theme or customize an existing one you should look
 == Minimum Requirements
 
 * asciidoctor 1.5.0
+
+== Copyright and Licensing
+
+Copyright (C) 2012-2016 Dan Allen and the Asciidoctor Project.
+Free use of this software is granted under the terms of the MIT License.
+
+See the <<LICENSE#,LICENSE>> file for details.


### PR DESCRIPTION
Based on on the asciidoctor/asciidoctor-backends repo practice.
No explicit individual contributers were highlighted (yet), As I
can only base this on the git commit history, which might be
errornous. So if individual contributers are to be attributed, this
should be done at a later time, by somebody more involved in this
project.

Relates to issue #65 created by me.