### PR TITLE
Limit named links to [a-zA-Z0-9\-\_\:\.]

### DIFF
--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -2,6 +2,7 @@
 - titleless = (title = self.title) == '!'
 - hide_title = (titleless || (option? :notitle) || (option? :conceal))
 - vertical_slides = find_by(context: :section) {|section| section.level == 2 }
+- @id = @id.gsub(/[^a-zA-Z0-9\-\_\:\.]/, '')
 
 / render parent section of vertical slides set
 - if @level == 1 && !vertical_slides.empty?


### PR DESCRIPTION
When working with other languages than English there are often nonlatin characters in section titles. When reveal.js is working with history enabled - this doesn't get resolved to proper navigation links (presentation starts over from the begining)

This is due to this reveal.js issue https://github.com/hakimel/reveal.js/issues/836 which resulted in a following pull request in reveal.js itself https://github.com/hakimel/reveal.js/commit/da82c8ce81a5acc8b14002a5818a32ce0c89f7b8

The important change is 
```
id = id.toLowerCase();
id = id.replace( /[^a-zA-Z0-9\-\_\:\.]/g, '' );
```

which I've added to the section template as well. 

I'm not sure if that's the way it should be done so feedback is appreciated