### PR TITLE
Replaced <kbd> element with <span> for the keyboard sequence.

### DIFF
--- a/templates/slim/inline_kbd.html.slim
+++ b/templates/slim/inline_kbd.html.slim
@@ -1,7 +1,7 @@
 - if (keys = attr 'keys').size == 1
   kbd=keys.first
 - else
-  kbd.keyseq
+  span.keyseq
     - keys.each_with_index do |key, idx|
       - unless idx.zero?
         |+


### PR DESCRIPTION
Regarding Asciidoctor's Ruby code, the keyboard sequence element should not be `<kbd>` but `<span>`

Here is the ruby code from [html5.rb](https://github.com/asciidoctor/asciidoctor/blob/ef7d3a113fd9b17470987cde845313a01129529f/lib/asciidoctor/converter/html5.rb) :

```
def inline_kbd node
  if (keys = node.attr 'keys').size == 1
    %(<kbd>#{keys[0]}</kbd>)
  else
    key_combo = keys.map {|key| %(<kbd>#{key}</kbd>+) }.join.chop
    %(<span class="keyseq">#{key_combo}</span>)
  end
end
```