### PR TITLE
Update multi-destination-content.adoc

### DIFF
--- a/test/multi-destination-content.adoc
+++ b/test/multi-destination-content.adoc
@@ -20,7 +20,7 @@ intro
 . of
 . items
 
-ifndef::escapingSillyPreprocessor[ifdef::backend-revealjs[=== !]]
+ifdef::backend-revealjs[=== !]
 
 Some overview
 
@@ -44,7 +44,7 @@ Some overview
 +-------------------------------------------------+
 ----
 
-ifndef::escapingSillyPreprocessor[ifdef::backend-revealjs[=== !]]
+ifdef::backend-revealjs[=== !]
 
 Detailed view
 


### PR DESCRIPTION
Correcting test case of asciidoctor/asciidoctor-reveal.js#69
"ifndef::escapingSillyPreprocessor" was meant only to allow a correct rendring of the README inside the github.com website.
It shouldnt appear in your test case