### PR TITLE
Video support improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -109,7 +109,7 @@ image::cover.jpg[background, size=cover]
 This will put `cover.jpg` as the slide's background image.
 It sets `reveal.js'` `data-background-image` attribute.
 The `size` attribute is also supported.
-See the https://github.com/hakimel/reveal.js/#image-backgrounds[reveal.js' documentation] for details.
+See the https://github.com/hakimel/reveal.js/#image-backgrounds[relevant reveal.js documentation] for details.
 
 NOTE: Background images file names are now relative to the `:imagedir:` attribute if set.
 
@@ -123,6 +123,47 @@ image::https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg[canv
 ----
 
 As you can see, you can use a URL to specify your image resource too.
+
+
+[#background_videos]
+=== Background videos
+
+A background video for a slide can be specified using the `background-video`
+element attribute.
+
+----
+[background-video="https://my.video/file.mp4",background-video-loop=true,background-video-muted=true]
+== Nice background!
+----
+
+For convenience `background-video-loop` and `background-video-muted`
+attributes are mapped to `loop` and `muted` options which can be specified
+with `options="loop,muted"`.
+
+For example:
+
+----
+[background-video="https://my.video/file.mp4",options="loop,muted"]
+== Nice background!
+----
+
+See https://github.com/hakimel/reveal.js#video-backgrounds[the relevant
+reveal.js documentation] for details.
+Note that the `data-` prefix is not required in asciidoc files.
+
+
+=== Background iframes
+
+The background can be replaced with anything a browser can render in an iframe
+using the `background-iframe` reveal.js feature.
+
+----
+[%notitle,background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&start=3&enablejsapi=1&autoplay=1&loop=1&controls=0&modestbranding=1"]
+== a youtube video
+----
+
+See https://github.com/hakimel/reveal.js#iframe-backgrounds[the relevant
+reveal.js documentation] for details.
 
 
 === Slide Transitions
@@ -139,7 +180,7 @@ This slide will override the presentation transition and zoom!
 Choose from three transition speeds: default, fast or slow!
 ----
 
-See https://github.com/hakimel/reveal.js/#slide-transitions[reveal.js' documentation] for details.
+See https://github.com/hakimel/reveal.js/#slide-transitions[the relevant reveal.js documentation] for details.
 
 
 === Fragments
@@ -157,7 +198,8 @@ See https://github.com/hakimel/reveal.js/#slide-transitions[reveal.js' documenta
 Slide Four has bullets that are revealed one after the other.
 This is what `reveal.js` calls http://lab.hakim.se/reveal-js/#/fragments[fragments].
 Applying the step option or role on a list (`[%step]` or `[.step]`) will do the trick.
-Here is https://github.com/hakimel/reveal.js#fragments[upstream documentation] on the topic.
+Here is https://github.com/hakimel/reveal.js#fragments[the relevant reveal.js
+documentation] on the topic.
 Note that only `fade-in` is supported for lists at the moment.
 
 
@@ -178,6 +220,24 @@ To apply that class to block simply use asciidoctor's class assignment:
 
 See https://github.com/hakimel/reveal.js#stretching-elements[reveal.js
 documentation on stretching elements].
+
+
+=== Videos
+
+In addition to <<background_videos,background videos>>, videos can be inserted
+directly into slides.
+The syntax is the standard
+http://asciidoctor.org/docs/user-manual/#video[asciidoc video block macro]
+syntax.
+
+----
+== Trains, we love trains!
+
+video::kZH9JtPBq7k[youtube, start=34, options=autoplay]
+----
+
+By default videos are given as much space as possible.
+To override that behavior use the `witdth` and `height` named attributes.
 
 
 === Syntax highlighting
@@ -245,7 +305,8 @@ This is a vertical subslide
 
 Slide Six uses the vertical slide feature of `reveal.js`.
 Slide Six.One will be rendered vertically below Slide Six.
-Here is https://github.com/hakimel/reveal.js#markup[upstream documentation] on that topic.
+Here is https://github.com/hakimel/reveal.js#markup[the relevant reveal.js
+documentation] on that topic.
 
 
 
@@ -258,8 +319,8 @@ title that look like this: `:name: value`.
 This back-end supports changing the color, image, video, iframe and
 transitions of the title slide.
 
-Read https://github.com/hakimel/reveal.js/#slide-backgrounds[`reveal.js`
-documentation] to understand what attributes need to be set.
+Read https://github.com/hakimel/reveal.js/#slide-backgrounds[the relevant
+reveal.js documentation] to understand what attributes need to be set.
 Keep in mind that for title slides you must replace `data-` with
 `title-slide-`.
 
@@ -440,7 +501,11 @@ Defaults to none
 Defaults to none
 |===
 
-If you want to build a custom theme or customize an existing one you should look at the https://github.com/hakimel/reveal.js/blob/master/css/theme/README.md[reveal.js documentation] and use the `revealjs_customtheme` AsciiDoc attribute to activate it.
+If you want to build a custom theme or customize an existing one you should
+look at the
+https://github.com/hakimel/reveal.js/blob/master/css/theme/README.md[reveal.js
+theme documentation] and use the `revealjs_customtheme` AsciiDoc attribute to
+activate it.
 
 == Minimum Requirements
 

--- a/README.adoc
+++ b/README.adoc
@@ -237,7 +237,7 @@ video::kZH9JtPBq7k[youtube, start=34, options=autoplay]
 ----
 
 By default videos are given as much space as possible.
-To override that behavior use the `witdth` and `height` named attributes.
+To override that behavior use the `width` and `height` named attributes.
 
 
 === Syntax highlighting

--- a/README.adoc
+++ b/README.adoc
@@ -92,8 +92,7 @@ NOTE: `conceal` and `notitle` have the advantage that the slide still has an id 
 Is very yellow
 ----
 
-Slide Three applies the attribute
-https://github.com/hakimel/reveal.js/#slide-backgrounds[data-background-color] to the `reveal.js` <section> tag.
+Slide Three applies the attribute https://github.com/hakimel/reveal.js/#slide-backgrounds[data-background-color] to the `reveal.js` <section> tag.
 Anything accepted by CSS color formats works.
 
 
@@ -128,17 +127,14 @@ As you can see, you can use a URL to specify your image resource too.
 [#background_videos]
 === Background videos
 
-A background video for a slide can be specified using the `background-video`
-element attribute.
+A background video for a slide can be specified using the `background-video` element attribute.
 
 ----
 [background-video="https://my.video/file.mp4",background-video-loop=true,background-video-muted=true]
 == Nice background!
 ----
 
-For convenience `background-video-loop` and `background-video-muted`
-attributes are mapped to `loop` and `muted` options which can be specified
-with `options="loop,muted"`.
+For convenience `background-video-loop` and `background-video-muted` attributes are mapped to `loop` and `muted` options which can be specified with `options="loop,muted"`.
 
 For example:
 
@@ -147,23 +143,20 @@ For example:
 == Nice background!
 ----
 
-See https://github.com/hakimel/reveal.js#video-backgrounds[the relevant
-reveal.js documentation] for details.
+See https://github.com/hakimel/reveal.js#video-backgrounds[the relevant reveal.js documentation] for details.
 Note that the `data-` prefix is not required in asciidoc files.
 
 
 === Background iframes
 
-The background can be replaced with anything a browser can render in an iframe
-using the `background-iframe` reveal.js feature.
+The background can be replaced with anything a browser can render in an iframe using the `background-iframe` reveal.js feature.
 
 ----
 [%notitle,background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&start=3&enablejsapi=1&autoplay=1&loop=1&controls=0&modestbranding=1"]
 == a youtube video
 ----
 
-See https://github.com/hakimel/reveal.js#iframe-backgrounds[the relevant
-reveal.js documentation] for details.
+See https://github.com/hakimel/reveal.js#iframe-backgrounds[the relevant reveal.js documentation] for details.
 
 
 === Slide Transitions
@@ -205,30 +198,24 @@ Note that only `fade-in` is supported for lists at the moment.
 
 == Stretch class attribute
 
-Reveal.js supports a special class that will give all available screen space
-to an HTML node.
+Reveal.js supports a special class that will give all available screen space to an HTML node.
 This class element is named `stretch`.
 
 __
-Sometimes it's desirable to have an element, like an image or video, stretch
-to consume as much space as possible within a given slide.
+Sometimes it's desirable to have an element, like an image or video, stretch to consume as much space as possible within a given slide.
 __
 
 To apply that class to block simply use asciidoctor's class assignment:
 
     [.stretch]
 
-See https://github.com/hakimel/reveal.js#stretching-elements[reveal.js
-documentation on stretching elements].
+See https://github.com/hakimel/reveal.js#stretching-elements[reveal.js documentation on stretching elements].
 
 
 === Videos
 
-In addition to <<background_videos,background videos>>, videos can be inserted
-directly into slides.
-The syntax is the standard
-http://asciidoctor.org/docs/user-manual/#video[asciidoc video block macro]
-syntax.
+In addition to <<background_videos,background videos>>, videos can be inserted directly into slides.
+The syntax is the standard http://asciidoctor.org/docs/user-manual/#video[asciidoc video block macro] syntax.
 
 ----
 == Trains, we love trains!

--- a/templates/slim/block_video.html.slim
+++ b/templates/slim/block_video.html.slim
@@ -1,31 +1,36 @@
-.videoblock id=@id class=[@style,role]
+/ in a slide-deck context we assume video should take as much place as possible
+/ unless already specified
+- no_stretch = ((attr? :width) || (attr? :height))
+- width = (attr? :width) ? :width : "100%"
+- height = (attr? :height) ? :height : "100%"
+/ we apply revealjs stretch class to the videoblock take all the place we can
+.videoblock id=@id class=[@style,role,(no_stretch ? nil : "stretch")]
   - if title?
     .title=captioned_title
-  .content
-    - case attr :poster
-    - when 'vimeo'
-      - unless (asset_uri_scheme = (attr :asset_uri_scheme, 'https')).empty?
-        -  asset_uri_scheme = %(#{asset_uri_scheme}:)
-      - start_anchor = (attr? :start) ? "#at=#{attr :start}" : nil
-      - delimiter = '?'
-      - autoplay_param = (option? 'autoplay') ? "#{delimiter}autoplay=1" : nil
-      - delimiter = '&amp;' if autoplay_param
-      - loop_param = (option? 'loop') ? "#{delimiter}loop=1" : nil
-      - src = %(#{asset_uri_scheme}//player.vimeo.com/video/#{attr :target}#{start_anchor}#{autoplay_param}#{loop_param})
-      iframe width=(attr :width) height=(attr :height) src=src frameborder=0 webkitAllowFullScreen=true mozallowfullscreen=true allowFullScreen=true
-    - when 'youtube'
-      - unless (asset_uri_scheme = (attr :asset_uri_scheme, 'https')).empty?
-        -  asset_uri_scheme = %(#{asset_uri_scheme}:)
-      - params = ['rel=0']
-      - params << "start=#{attr :start}" if attr? :start
-      - params << "end=#{attr :end}" if attr? :end
-      - params << "autoplay=1" if option? 'autoplay'
-      - params << "loop=1" if option? 'loop'
-      - params << "controls=0" if option? 'nocontrols'
-      - src = %(#{asset_uri_scheme}//www.youtube.com/embed/#{attr :target}?#{params * '&amp;'})
-      iframe width=(attr :width) height=(attr :height) src=src frameborder=0 allowfullscreen=!(option? 'nofullscreen')
-    - else
-      video(src=media_uri(attr :target) width=(attr :width) height=(attr :height)
-          poster=((attr :poster) ? media_uri(attr :poster) : nil) autoplay=(option? 'autoplay')
-          controls=!(option? 'nocontrols') loop=(option? 'loop'))
-        |Your browser does not support the video tag.
+  - case attr :poster
+  - when 'vimeo'
+    - unless (asset_uri_scheme = (attr :asset_uri_scheme, 'https')).empty?
+      -  asset_uri_scheme = %(#{asset_uri_scheme}:)
+    - start_anchor = (attr? :start) ? "#at=#{attr :start}" : nil
+    - delimiter = '?'
+    - autoplay_param = (option? 'autoplay') ? "#{delimiter}autoplay=1" : nil
+    - delimiter = '&amp;' if autoplay_param
+    - loop_param = (option? 'loop') ? "#{delimiter}loop=1" : nil
+    - src = %(#{asset_uri_scheme}//player.vimeo.com/video/#{attr :target}#{start_anchor}#{autoplay_param}#{loop_param})
+    iframe width=(width) height=(height) src=src frameborder=0 webkitAllowFullScreen=true mozallowfullscreen=true allowFullScreen=true
+  - when 'youtube'
+    - unless (asset_uri_scheme = (attr :asset_uri_scheme, 'https')).empty?
+      -  asset_uri_scheme = %(#{asset_uri_scheme}:)
+    - params = ['rel=0']
+    - params << "start=#{attr :start}" if attr? :start
+    - params << "end=#{attr :end}" if attr? :end
+    - params << "autoplay=1" if option? 'autoplay'
+    - params << "loop=1" if option? 'loop'
+    - params << "controls=0" if option? 'nocontrols'
+    - src = %(#{asset_uri_scheme}//www.youtube.com/embed/#{attr :target}?#{params * '&amp;'})
+    iframe width=(width) height=(height) src=src frameborder=0 allowfullscreen=!(option? 'nofullscreen')
+  - else
+    video(src=media_uri(attr :target) width=(width) height=(height)
+        poster=((attr :poster) ? media_uri(attr :poster) : nil) autoplay=(option? 'autoplay')
+        controls=!(option? 'nocontrols') loop=(option? 'loop'))
+      |Your browser does not support the video tag.

--- a/templates/slim/block_video.html.slim
+++ b/templates/slim/block_video.html.slim
@@ -13,24 +13,28 @@
       -  asset_uri_scheme = %(#{asset_uri_scheme}:)
     - start_anchor = (attr? :start) ? "#at=#{attr :start}" : nil
     - delimiter = '?'
-    - autoplay_param = (option? 'autoplay') ? "#{delimiter}autoplay=1" : nil
-    - delimiter = '&amp;' if autoplay_param
     - loop_param = (option? 'loop') ? "#{delimiter}loop=1" : nil
-    - src = %(#{asset_uri_scheme}//player.vimeo.com/video/#{attr :target}#{start_anchor}#{autoplay_param}#{loop_param})
-    iframe width=(width) height=(height) src=src frameborder=0 webkitAllowFullScreen=true mozallowfullscreen=true allowFullScreen=true
+    - src = %(#{asset_uri_scheme}//player.vimeo.com/video/#{attr :target}#{start_anchor}#{loop_param})
+    iframe(width=(width) height=(height) src=src frameborder=0
+      webkitAllowFullScreen=true mozallowfullscreen=true allowFullScreen=true
+      data-autoplay=(option? 'autoplay'))
+    / data-autoplay is not supported on vimeo videos
+    / upstream: https://github.com/hakimel/reveal.js/issues/388
   - when 'youtube'
     - unless (asset_uri_scheme = (attr :asset_uri_scheme, 'https')).empty?
       -  asset_uri_scheme = %(#{asset_uri_scheme}:)
     - params = ['rel=0']
     - params << "start=#{attr :start}" if attr? :start
     - params << "end=#{attr :end}" if attr? :end
-    - params << "autoplay=1" if option? 'autoplay'
     - params << "loop=1" if option? 'loop'
     - params << "controls=0" if option? 'nocontrols'
     - src = %(#{asset_uri_scheme}//www.youtube.com/embed/#{attr :target}?#{params * '&amp;'})
-    iframe width=(width) height=(height) src=src frameborder=0 allowfullscreen=!(option? 'nofullscreen')
+    iframe(width=(width) height=(height) src=src
+      frameborder=0 allowfullscreen=!(option? 'nofullscreen')
+      data-autoplay=(option? 'autoplay'))
   - else
     video(src=media_uri(attr :target) width=(width) height=(height)
-        poster=((attr :poster) ? media_uri(attr :poster) : nil) autoplay=(option? 'autoplay')
-        controls=!(option? 'nocontrols') loop=(option? 'loop'))
+      poster=((attr :poster) ? media_uri(attr :poster) : nil)
+      data-autoplay=(option? 'autoplay') controls=!(option? 'nocontrols')
+      loop=(option? 'loop'))
       |Your browser does not support the video tag.

--- a/templates/slim/block_video.html.slim
+++ b/templates/slim/block_video.html.slim
@@ -1,8 +1,8 @@
 / in a slide-deck context we assume video should take as much place as possible
 / unless already specified
 - no_stretch = ((attr? :width) || (attr? :height))
-- width = (attr? :width) ? :width : "100%"
-- height = (attr? :height) ? :height : "100%"
+- width = (attr? :width) ? (attr :width) : "100%"
+- height = (attr? :height) ? (attr :height) : "100%"
 / we apply revealjs stretch class to the videoblock take all the place we can
 .videoblock id=@id class=[@style,role,(no_stretch ? nil : "stretch")]
   - if title?

--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -42,7 +42,12 @@
       data-background-image=data_background_image
       data-background-size=(data_background_size || attr('background-size'))
       data-background-repeat=(data_background_repeat || attr('background-repeat'))
-      data-background-transition=(data_background_transition || attr('background-transition')))
+      data-background-transition=(data_background_transition || attr('background-transition'))
+      data-background-iframe=(attr "background-iframe")
+      data-background-video=(attr "background-video")
+      data-background-video-loop=((attr? 'background-video-loop') || (option? 'loop'))
+      data-background-video-muted=((attr? 'background-video-muted') || (option? 'muted')))
+
       - unless hide_title
         h2=title
       - (blocks - vertical_slides).each do |block|
@@ -65,7 +70,12 @@
       data-background-image=data_background_image
       data-background-size=(data_background_size || attr('background-size'))
       data-background-repeat=(data_background_repeat || attr('background-repeat'))
-      data-background-transition=(data_background_transition || attr('background-transition')))
+      data-background-transition=(data_background_transition || attr('background-transition'))
+      data-background-iframe=(attr "background-iframe")
+      data-background-video=(attr "background-video")
+      data-background-video-loop=((attr? 'background-video-loop') || (option? 'loop'))
+      data-background-video-muted=((attr? 'background-video-muted') || (option? 'muted')))
+
       - unless hide_title
         h2=title
       =content.chomp

--- a/test/video.adoc
+++ b/test/video.adoc
@@ -1,0 +1,20 @@
+= Video tests
+
+== Auto-sized
+
+video::kZH9JtPBq7k[youtube, start=34, options=autoplay]
+//video::kZH9JtPBq7k[youtube, start=34, height=600, width=800, options=autoplay]
+
+[%notitle]
+== Auto-sized notitle
+
+video::kZH9JtPBq7k[youtube, start=34, options=autoplay]
+
+[%notitle,background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&start=3&enablejsapi=1&autoplay=1&loop=1&controls=0&modestbranding=1"]
+== background
+
+[%notitle,background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm",background-video-loop=true,background-video-muted=true]
+== video file, named attributes
+
+[background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm",options="loop,muted,notitle"]
+== video file, options

--- a/test/video.adoc
+++ b/test/video.adoc
@@ -18,3 +18,11 @@ video::kZH9JtPBq7k[youtube, start=34, options=autoplay]
 
 [background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm",options="loop,muted,notitle"]
 == video file, options
+
+
+== vimeo autostart
+
+video::44878206[vimeo, options=autoplay]
+
+// data-autoplay is not supported on vimeo videos
+// upstream: https://github.com/hakimel/reveal.js/issues/388


### PR DESCRIPTION
Made several improvements to the support and documentation around videos. Fixes #71.

* background videos on individual slides is supported (w/ shorthand options)
* videos by default will use a saner size (`[.stretch]`)
* everything is documented

The PR is larger than it should because I branched it from `data-background-rework` and rebased it from master before pushing. Once #52 is merged, I'll rebase again on master and reviewing should be a lot more straightforward.

Task list:
- [x] merge PR #52 
- [ ] Try to find another solution than `.stretch` class to make video large (100% or cover/contain sizes?)
- [x] issue: inline video `options="autoplay"` makes the video start at prefetch time which is too soon
- [x] re-wrap documentation to one sentence per line