### PR TITLE
hr is self closing and should not have content

### DIFF
--- a/templates/jade/embedded.jade
+++ b/templates/jade/embedded.jade
@@ -4,8 +4,8 @@ unless node.$notitle() || !node['$has_header?']()
 unless !node['$footnotes?']() || node['$attr?']('nofootnotes')
   div(id='footnotes')
     hr
-      each fn in node.$footnotes()
-        div.footnote(id='_footnote_' + fn.$index())
-          a(href='#_footnoteref_' + fn.$index())
-            !{fn.$index()}
-          !{fn.$text()}
+    each fn in node.$footnotes()
+      div.footnote(id='_footnote_' + fn.$index())
+        a(href='#_footnoteref_' + fn.$index())
+          !{fn.$index()}
+        !{fn.$text()}


### PR DESCRIPTION
Resolves the following issue with Jade 1.11.0:

```
    Error: Jade:6
        4| unless !node['$footnotes?']() || node['$attr?']('nofootnotes')
        5|   div(id='footnotes')
      > 6|     hr
        7|       each fn in node.$footnotes()
        8|         div.footnote(id='_footnote_' + fn.$index())
        9|           a(href='#_footnoteref_' + fn.$index())
    
    hr is self closing and should not have content. (line 6)
```