### PR TITLE
Adds package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test/*.html
 test/reveal.js/
 node_modules/
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test/*.html
 test/reveal.js/
+node_modules/

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -1,6 +1,7 @@
 = HACKING asciidoctor-reveal.js
 :toc: preamble
 :toclevels: 2
+:uri-nodejs-download: https://nodejs.org/en/download/
 
 Short instructions that aim to help potential contributors.
 
@@ -190,3 +191,94 @@ You might even be able to get some feedback early which could save you some time
 You can apply that label to a pull request that is complete and ready for review.
 
 Makes triaging easier.
+
+
+== Node package
+
+=== Initial setup
+
+First you must install and configure {uri-nodejs-download}[Node.js] on your machine.
+
+=== Setup a test project
+
+In order to test the Node package, you need to create a test project adjacent to the clone of the `asciidoctor-reveal.js` repository:
+
+ $ mkdir test-project
+ $ cd test-project
+ $ npm init -y
+
+Now, install the dependencies:
+
+ $ npm i --save asciidoctor.js@1.5.5-2
+ $ npm i --save asciidoctor-template.js@1.5.5-2
+ $ npm i --save ../asciidoctor-reveal.js
+
+IMPORTANT: As mentioned above, the `asciidoctor-reveal.js` repository must be cloned next to the `test-projet` directory.
+
+Create an AsciiDoc file:
+
+[source]
+----
+$ cat <<- EOF > presentation.adoc
+= Title Slide
+// depending on your npm version, you might have to try the other 'revealjsdir' value.
+//:revealjsdir: node_modules/reveal.js
+
+== Slide One
+
+* Foo
+* Bar
+* World
+
+== Slide Two
+
+Hello World - Good Bye Cruel World
+
+[NOTE.speaker]
+--
+Actually things aren't that bad
+--
+EOF
+----
+
+Use the Asciidoctor API to convert an AsciiDoc file into a Reveal.js presentation:
+
+[source]
+----
+$ cat <<- 'EOF' > asciidoctor-revealjs.js
+// Load asciidoctor.js + asciidoctor-template.js
+var asciidoctor = require('asciidoctor.js')();
+var Asciidoctor = asciidoctor.Asciidoctor();
+var Opal = asciidoctor.Opal;
+Opal.load('nodejs');
+Opal.load('pathname');
+require('asciidoctor-template.js');
+
+// Convert the document 'presentation.adoc' using Reveal.js backend
+var attributes = 'revealjsdir=node_modules/asciidoctor-reveal.js/node_modules/reveal.js';
+var options = Opal.hash({safe: 'safe',
+                         backend: 'revealjs',
+                         attributes: attributes});
+Asciidoctor.$convert_file('presentation.adoc', options);
+EOF
+----
+
+Run the following command:
+
+ $ node asciidoctor-revealjs.js
+
+A file named `presentation.html` has been created in the `test-project` directory.
+You can open this file in your browser and enjoy!
+
+=== Publish a new version
+
+. Update the "version" field in `package.json`
+. Commit and push your changes
+. Create a tag
+. Using npm:
++
+ $ npm login
+ $ npm publish
+
+. Check that the new version is available on https://www.npmjs.com/package/asciidoctor-reveal.js[npmjs.com]
+

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = reveal.js backend for Asciidoctor
 :toc: preamble
 :toclevels: 2
+:uri-nodejs-download: https://nodejs.org/en/download/
 
 The https://github.com/asciidoctor/asciidoctor-reveal.js[reveal.js backend] is a collection of Slim templates for https://github.com/asciidoctor/asciidoctor[Asciidoctor] that transform an AsciiDoc document into HTML5 slides animated by http://lab.hakim.se/reveal-js/[reveal.js].
 
@@ -8,6 +9,8 @@ The https://github.com/asciidoctor/asciidoctor-reveal.js[reveal.js backend] is a
 
 
 == Prerequisites
+
+NOTE: Since Asciidoctor can run in JavaScript, we also provide a <<node-package>>.
 
 . Ensure Asciidoctor, Slim and their dependencies are installed:
 
@@ -20,7 +23,6 @@ The https://github.com/asciidoctor/asciidoctor-reveal.js[reveal.js backend] is a
 . Copy or clone presentation library (to output destination/branch)
 
   $ git clone -b 3.0.0 git://github.com/hakimel/reveal.js.git
-
 
 == Rendering the AsciiDoc into slides
 
@@ -35,6 +37,39 @@ NOTE: If you want to use reveal.js 2, please switch your asciidoctor-reveal.js r
 
 TIP: If you are using https://pages.github.com/[GitHub Pages], plan ahead by keeping your source files on `master` branch and all output files on the `gh-pages` branch.
 
+[[node-package]]
+== Node package
+
+First you must install and configure {uri-nodejs-download}[Node.js] on your machine.
+
+Using npm:
+
+ $ npm i --save asciidoctor.js@1.5.5-2
+ $ npm i --save asciidoctor-template.js@1.5.5-2
+ $ npm i --save asciidoctor-reveal.js@1.5.5-2
+
+Once the package is installed, you can convert AsciiDoc files using Reveal.js backend.
+Here we are converting a file named `presentation.adoc` into a Reveal.js presentation using Node.js:
+
+.asciidoctor-revealjs.js
+[source, javascript]
+----
+// Load asciidoctor.js + asciidoctor-template.js
+var asciidoctor = require('asciidoctor.js')();
+var Asciidoctor = asciidoctor.Asciidoctor();
+var Opal = asciidoctor.Opal;
+Opal.load('nodejs');
+Opal.load('pathname');
+require('asciidoctor-template.js');
+
+// Convert the document 'presentation.adoc' using Reveal.js backend
+var attributes = 'revealjsdir=node_modules/asciidoctor-reveal.js/node_modules/reveal.js';
+var options = Opal.hash({safe: 'safe',
+                         backend: 'revealjs',
+                         attributes: attributes});
+Asciidoctor.$convert_file('presentation.adoc', options); // <1>
+----
+<1> Create a file named `presentation.html` (in the directory where command is run)
 
 == Some Examples
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "asciidoctor-reveal.js",
+  "version": "1.5.5-2",
+  "description": "Reveal.js backend templates for Asciidoctor.js, implemented in Jade",
+  "engines": {
+    "node": ">=0.12"
+  },
+  "files": [
+    "templates/jade",
+    "LICENSE.adoc",
+    "README.adoc"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/asciidoctor/asciidoctor-reveal.js.git"
+  },
+  "keywords": [
+    "asciidoc",
+    "asciidoctor",
+    "opal",
+    "javascript",
+    "library",
+    "backend",
+    "template",
+    "reveal.js",
+    "jade"
+  ],
+  "authors": [
+    "Guillaume Grossetie (https://github.com/mogztter)"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/asciidoctor/asciidoctor-reveal.js/issues"
+  },
+  "homepage": "https://github.com/asciidoctor/asciidoctor-reveal.js",
+  "dependencies": {
+    "reveal.js": "3.3.0",
+    "asciidoctor-template.js": "1.5.5-2"
+  }
+}

--- a/templates/jade/document.jade
+++ b/templates/jade/document.jade
@@ -2,6 +2,7 @@ doctype html
 html(lang=node.document.$attr("lang", "en") )
   head
     meta(charset="UTF-8")
+    - revealjsdir = node.$attr('revealjsdir', 'reveal.js')
     each key in ["description","keywords","author","copyright"]
       if node.$attr(key, false)
         meta(name=key,content=node.$attr(key))
@@ -10,21 +11,21 @@ html(lang=node.document.$attr("lang", "en") )
     meta(content="black-translucent",name="apple-mobile-web-app-status-bar-style")
     meta(content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui",name="viewport")
     link(href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css",rel="stylesheet")
-    link(href="reveal.js/css/reveal.css",rel="stylesheet")
+    link(href="#{revealjsdir}/css/reveal.css",rel="stylesheet")
     if node.$attr("revealjs_customtheme", false)
       link(rel='stylesheet',href="#{node.$attr('revealjs_customtheme')}",id='theme')
     else
-      link(rel='stylesheet',href='reveal.js/css/theme/serif.css',id='theme')
-    link(href="reveal.js/lib/css/zenburn.css",rel="stylesheet")
+      link(rel='stylesheet',href='#{revealjsdir}/css/theme/serif.css',id='theme')
+    link(href="#{revealjsdir}/lib/css/zenburn.css",rel="stylesheet")
     script(src = "http://getfirebug.com/firebug-lite.js#startOpened=false")
     script(type='text/javascript').
-      document.write('<link rel="stylesheet" href="reveal.js/css/print/' + ( window.location.search.match(/print-pdf/gi) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">');
+      document.write('<link rel="stylesheet" href="#{revealjsdir}/css/print/' + ( window.location.search.match(/print-pdf/gi) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">');
   body
     .reveal
       .slides
         !{node.$content()}
-    script(src = "reveal.js/lib/js/head.min.js")
-    script(src = "reveal.js/js/reveal.js")
+    script(src = "#{revealjsdir}/lib/js/head.min.js")
+    script(src = "#{revealjsdir}/js/reveal.js")
     script(type='text/javascript').
       function initializeReveal() {
         // See https://github.com/hakimel/reveal.js#configuration for a full list of configuration options
@@ -83,20 +84,19 @@ html(lang=node.document.$attr("lang", "en") )
           // Optional libraries used to extend on reveal.js
           dependencies: [
             {
-              src: 'reveal.js/lib/js/classList.js', condition: function () {
-              return !document.body.classList;
-            }
+              src: '#{revealjsdir}/lib/js/classList.js',
+              condition: function () { return !document.body.classList; }
             },
-            #{(node.$attr('source-highlighter') == 'highlight.js') ? "{ src: 'reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }," : ""}
+            #{(node.$attr('source-highlighter') == 'highlight.js') ? "{ src: '#{revealjsdir}/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }," : ""}
             {
-              src: 'reveal.js/plugin/zoom-js/zoom.js', async: true, condition: function () {
-              return !!document.body.classList;
-            }
+              src: '#{revealjsdir}/plugin/zoom-js/zoom.js',
+              async: true,
+              condition: function () { return !!document.body.classList; }
             },
             {
-              src: 'reveal.js/plugin/notes/notes.js', async: true, condition: function () {
-              return !!document.body.classList;
-            }
+              src: '#{revealjsdir}/plugin/notes/notes.js',
+              async: true,
+              condition: function () { return !!document.body.classList; }
             }
           ]
         });


### PR DESCRIPTION
The goal is to make this backend easily available on the Node ecosystem.
I've created a simple converter for Jade templates (compiled in JavaScript with Opal) that will be available soon on `npmjs`: https://github.com/Mogztter/asciidoctor-template.js

When both projets will be published on `npmjs`, a user will be able to convert an AsciiDoc document into a Reveal.js presentation as follows:

``` sh
npm install asciidoctor.js # AFAIK this is only required on npm 2.x
npm install asciidoctor-reveal.js
```

``` javascript
// Loads Asciidoctor.js + Asciidoctor-template.js
var asciidoctor = require('asciidoctor.js')();
var Asciidoctor = asciidoctor.Asciidoctor();
var Opal = asciidoctor.Opal;
Opal.load('nodejs');
Opal.load('pathname');
require('asciidoctor-template.js');

var options = Opal.hash({'safe': 'safe',
                         'template_dir': 'node_modules/asciidoctor-reveal.js/templates',
                         'backend': 'revealjs'});

var content = '...'; // AsciiDoc content
var result = Asciidoctor.$convert(content, options); // Congrats you have a Reveal.js presentation !
```

Feel free to add authors and a better description :smile: 
