### PR TITLE
Fixed vertical slides and background problem

### DIFF
--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -13,8 +13,10 @@
 - data_background_image, data_background_size, data_background_repeat,
   data_background_transition = nil
 
+/ find all images under current node with attribute background or canvas
+/ as long as they are of the same level as we are currently processing
 - slide_images = find_by(:context => :image) { |image|
--   image.attr(1) == 'background' || image.attr(1) == 'canvas'
+-   (image.attr(1) == 'background' || image.attr(1) == 'canvas') && image.level == level
 - }
 - unless slide_images.nil? or slide_images.length == 0
   - slide_images.each do |image|

--- a/test/data-background-newstyle.adoc
+++ b/test/data-background-newstyle.adoc
@@ -49,3 +49,10 @@ image::https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg[back
 
 [background-color=yellow]
 == No [yellow] regression
+
+
+== Empty Vertical top
+
+=== Vertical with background
+
+image::70s.jpg[canvas, size=cover]


### PR DESCRIPTION
As reported in #96, a first vertical slide w/o a background should not show the next vertical slide's background.

Here's a fix for it. I'm not 100% satisfied with it (given that it spans for longer than 80 chars) but it works.

Integrated the user-provided test case (and we love those! :+1:).