### PR TITLE
Changed regex, so it does not remove first letter of id

### DIFF
--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -1,6 +1,6 @@
 / OPTIONS PROCESSING
 / strip IDs the same way revealjs does (remove when hakimel/reveal.js#1230 is fixed)
-- @id = @id.gsub(/^[a-zA-Z0-9\-\_\:\.]/, '')
+- @id = @id.gsub(/[^a-zA-Z0-9\-\_\:\.]/, '')
 
 / hide slides on %conceal, %notitle and named "!"
 - titleless = (title = self.title) == '!'
@@ -8,7 +8,7 @@
 
 - vertical_slides = find_by(context: :section) {|section| section.level == 2 }
 
-/ extracting block image attributes to find an image to use as a 
+/ extracting block image attributes to find an image to use as a
 / background_image attribute
 - data_background_image, data_background_size, data_background_repeat,
   data_background_transition = nil


### PR DESCRIPTION
The regex removes the first character of the title in the id, making

 == P2P Applications

have "2p-applications" as id, failing in navigation, as it starts with a number.