### PR TITLE
node: Using @ attribute prefix to lower CLI priority

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,8 +63,10 @@ Opal.load('pathname');
 require('asciidoctor-template.js');
 
 // Convert the document 'presentation.adoc' using Reveal.js backend
+var attributes = 'revealjsdir@=node_modules/reveal.js';
 var options = Opal.hash({safe: 'safe',
-                         backend: 'revealjs'});
+                         backend: 'revealjs',
+                         attributes: attributes});
 Asciidoctor.$convert_file('presentation.adoc', options); // <1>
 ----
 <1> Creates a file named `presentation.html` (in the directory where command is run)
@@ -73,9 +75,9 @@ Asciidoctor.$convert_file('presentation.adoc', options); // <1>
 [source, asciidoc]
 ----
 = Title Slide
-// depending on your npm version, you might have to try the other 'revealjsdir' value.
-//:revealjsdir: node_modules/reveal.js
-:revealjsdir: node_modules/asciidoctor-reveal.js/node_modules/reveal.js
+// depending on your npm version, you might need to override the default
+// 'revealjsdir' value by removing the comments from the line below:
+//:revealjsdir: node_modules/asciidoctor-reveal.js/node_modules/reveal.js
 
 == Slide One
 


### PR DESCRIPTION
Related to discussion in #95. Allows our example to avoid :revealjsdir: document attribute in recent node versions while still allowing per-document overrides.

Took the opportunity to reverse the default value as discussed.

Let me know if it's good for you.