### PR TITLE
Added a minimal README for the npm package

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 :toclevels: 2
 :uri-nodejs-download: https://nodejs.org/en/download/
 
+// Changes made here should be sync'ed in packages.json's readme field
 The https://github.com/asciidoctor/asciidoctor-reveal.js[reveal.js backend] is a collection of Slim templates for https://github.com/asciidoctor/asciidoctor[Asciidoctor] that transform an AsciiDoc document into HTML5 slides animated by http://lab.hakim.se/reveal-js/[reveal.js].
 
 //image:https://travis-ci.org/asciidoctor/asciidoctor-reveal.js.svg?branch=master[Build Status,link=https://travis-ci.org/asciidoctor/asciidoctor-reveal.js]

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
   "dependencies": {
     "reveal.js": "3.3.0",
     "asciidoctor-template.js": "1.5.5-2"
-  }
+  },
+  "readme": "# reveal.js backend for Asciidoctor\n\nThe [reveal.js backend](https://github.com/asciidoctor/asciidoctor-reveal.js) is a collection of templates for [Asciidoctor](https://github.com/asciidoctor/asciidoctor) (or [Asciidoctor.js](https://github.com/asciidoctor/asciidoctor.js)) that transform an AsciiDoc document into HTML5 slides animated by [reveal.js](http://lab.hakim.se/reveal-js/).\n\nThis is the npm module. For setup instructions and the AsciiDoc syntax to use to write a presentation see the module's documentation at [https://github.com/asciidoctor/asciidoctor-reveal.js](https://github.com/asciidoctor/asciidoctor-reveal.js).\n"
 }


### PR DESCRIPTION
The idea is to provide a minimal README so that it points to our GitHub README and we don't need to update it too often.

Filed upstream issue: https://github.com/npm/npm/issues/14159