### PR TITLE
Apply data-state 'title' to the title slide

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,7 @@
 = {project-name} Changelog
 :project-name: asciidoctor-reveal.js
 :uri-repo: https://github.com/asciidoctor/asciidoctor-reveal.js
+:uri-issue: {uri-repo}/issues/
 
 This document provides a high-level view of the changes introduced in {project-name} by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
@@ -10,10 +11,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Enhancements::
   * Documentation improvements
 
-////
 Compliance::
-  * item
+  * Added `data-state: title` to the title slide ({uri-issue}123[#123])
 
+////
 Bug fixes::
   * item
 

--- a/templates/slim/document.html.slim
+++ b/templates/slim/document.html.slim
@@ -75,6 +75,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
           - bg_image = (attr? 'title-slide-background-image') ? (image_uri(attr 'title-slide-background-image')) : nil
           - bg_video = (attr? 'title-slide-background-video') ? (media_uri(attr 'title-slide-background-video')) : nil
           section.title(class = role
+            data-state='title'
             data-transition=(attr 'title-slide-transition')
             data-transition-speed=(attr 'title-slide-transition-speed')
             data-background=(attr 'title-slide-background')


### PR DESCRIPTION
Some fancy stuff mind end up outside of slide sections and to give it special treatment on the title slide, the section's CSS class `title` does not suffice. (See a use case [here](http://slides.codefx.org/junit-5/2017-01-25-JUG-Karlsruhe), where the footer only shows from the second slide forward.)

This change applies the data-state `title` to the title slide, making reveal.js apply it as a CSS class to the document when the title slide is active.