### PR TITLE
Update asciidoctor-revealjs.gemspec

### DIFF
--- a/asciidoctor-revealjs.gemspec
+++ b/asciidoctor-revealjs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = Dir['README.adoc', 'LICENSE.adoc', 'HACKING.adoc']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'asciidoctor', '~> 1.5.6.1'
+  s.add_runtime_dependency 'asciidoctor', '~> 1.5.6'
   s.add_runtime_dependency 'slim', '~> 3.0.6'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.5'
 

--- a/asciidoctor-revealjs.gemspec
+++ b/asciidoctor-revealjs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = Dir['README.adoc', 'LICENSE.adoc', 'HACKING.adoc']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'asciidoctor', '~> 1.5.4'
+  s.add_runtime_dependency 'asciidoctor', '~> 1.5.6.1'
   s.add_runtime_dependency 'slim', '~> 3.0.6'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.5'
 


### PR DESCRIPTION
Is it possible to update the gemset to the latest release version of asciidoctor ?

I would like to add `asciidoctor-revealjs` to the list of gems in [nixos](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/typesetting/asciidoctor/Gemfile) without carrying different versions of asciidoctor. 