### PR TITLE
resolves #132 fix templates to work with 1.5.6

### DIFF
--- a/asciidoctor-revealjs.gemspec
+++ b/asciidoctor-revealjs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = Dir['README.adoc', 'LICENSE.adoc', 'HACKING.adoc']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'asciidoctor', '= 1.5.4'
+  s.add_runtime_dependency 'asciidoctor', '~> 1.5.6'
   s.add_runtime_dependency 'slim', '~> 3.0.6'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.5'
 

--- a/templates/slim/block_admonition.html.slim
+++ b/templates/slim/block_admonition.html.slim
@@ -7,11 +7,11 @@
       td.icon
         - if @document.attr? :icons, 'font'
           - icon_mapping = Hash['caution', 'fire', 'important', 'exclamation-circle', 'note', 'info-circle', 'tip', 'lightbulb-o', 'warning', 'warning']
-          i class=%(fa fa-#{icon_mapping[attr :name]}) title=@caption
+          i class=%(fa fa-#{icon_mapping[attr :name]}) title=(attr :textlabel) || @caption
         - elsif @document.attr? :icons
           img src=icon_uri(attr :name) alt=@caption
         - else
-          .title=@caption
+          .title=(attr :textlabel) || @caption
       td.content
         - if title?
           .title=title

--- a/templates/slim/block_image.html.slim
+++ b/templates/slim/block_image.html.slim
@@ -9,7 +9,7 @@
 - if (has_role? 'stretch') && !((attr? :width) || (attr? :height))
   - height = "100%"
 
-- unless attr(1) == 'background' || attr(1) == "canvas"
+- unless attributes[1] == 'background' || attributes[1] == 'canvas'
   .imageblock(id=@id class=roles
       style=[("text-align: #{attr :align}" if attr? :align),("float: #{attr :float}" if attr? :float)].compact.join('; '))
     - if attr? :link

--- a/templates/slim/block_listing.html.slim
+++ b/templates/slim/block_listing.html.slim
@@ -5,7 +5,7 @@
     - nowrap = !(@document.attr? :prewrap) || (option? 'nowrap')
     / implicit listing blocks and source blocks are rendered as code
     / explicit listing blocks stay listing
-    - if @style == 'source' || (@style == 'listing' && !(attr? 1, 'listing'))
+    - if @style == 'source' || (@style == 'listing' && attributes[1] != 'listing')
       - language = attr :language
       - code_class = language ? [language, "language-#{language}"] : nil
       - pre_class = ['highlight']

--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -16,11 +16,11 @@
 / process the first image block in the current section that acts as a background
 - section_images = blocks.map do |block|
   - if (ctx = block.context) == :image
-    - ['background', 'canvas'].include?(block.attr 1) ? block : []
+    - ['background', 'canvas'].include?(block.attributes[1]) ? block : []
   - elsif ctx == :section
     - []
   - else
-    - block.find_by(context: :image) {|image| ['background', 'canvas'].include?(image.attr 1) } || []
+    - block.find_by(context: :image) {|image| ['background', 'canvas'].include?(image.attributes[1]) } || []
 - if (bg_image = section_images.flatten.first)
   - data_background_image = image_uri(bg_image.attr 'target')
   / make sure no crash on nil and default values make sense


### PR DESCRIPTION
- use attributes[1] to access first positional attribute
- use textlabel to access textual label of admonition block