### PR TITLE
Reveal.js compatible slide id generation fixes history feature (#127)

### DIFF
--- a/examples/history-regression-tests.adoc
+++ b/examples/history-regression-tests.adoc
@@ -14,4 +14,21 @@
 == P3rhaps this won't work
 // Second char is a number
 
+== 5th Slide
+// is it skipped by reveal.js?
+
 == Illegal çhàrâctérß
+
+[[explicit]]
+== Explicit section id
+
+== 67848727
+// Everything should be stripped in the id
+
+== Repeated title
+
+== !
+// Explicit no title
+
+== Repeated title
+// Exact same title means exact same id

--- a/templates/section.html.slim
+++ b/templates/section.html.slim
@@ -1,6 +1,9 @@
 / OPTIONS PROCESSING
-/ strip IDs the same way revealjs does (remove when hakimel/reveal.js#1230 is fixed)
-- _id = id.gsub(/[^a-zA-Z0-9\-\_\:\.]/, '')
+/ strip IDs the same way revealjs does to make links to direct slides work using URL fragments gh#127
+/ Strip unallowed characters globally then strip anything non a-Z from start of string until something matches
+/ TODO remove when hakimel/reveal.js#1230 is fixed
+- _id = id.gsub(/[^a-zA-Z0-9\-\_\:\.]/, '').gsub(/^[^a-zA-Z]+/, '')
+
 
 / hide slides on %conceal, %notitle and named "!"
 - titleless = (title = self.title) == '!'

--- a/test/doctest/concealed-slide-titles.html
+++ b/test/doctest/concealed-slide-titles.html
@@ -8,12 +8,12 @@
       <p>This</p>
     </div>
   </section>
-  <section id="_presentation">
+  <section id="presentation">
     <div class="paragraph">
       <p>presentation’s titles</p>
     </div>
   </section>
-  <section id="_concealed">
+  <section id="concealed">
     <div class="paragraph">
       <p>should be concealed</p>
     </div>

--- a/test/doctest/customcss.html
+++ b/test/doctest/customcss.html
@@ -4,7 +4,7 @@
     <h1>Custom CSS</h1>
     <p class="author"><small>Author</small></p>
   </section>
-  <section id="_slide_1">
+  <section id="slide_1">
     <h2>Slide 1</h2>
   </section>
 </div>

--- a/test/doctest/data-background-newstyle.html
+++ b/test/doctest/data-background-newstyle.html
@@ -3,14 +3,14 @@
   <section class="title" data-state="title">
     <h1>Test slide deck</h1>
   </section>
-  <section data-background-image="images/cover.jpg" data-background-size="cover" id="_opening"></section>
-  <section data-background-image="images/cover.jpg" data-background-size="cover" id="_canvas">
+  <section data-background-image="images/cover.jpg" data-background-size="cover" id="opening"></section>
+  <section data-background-image="images/cover.jpg" data-background-size="cover" id="canvas">
     <h2>canvas</h2>
   </section>
   <section data-background-image="images/70s.jpg" data-background-size="cover">
     <div class="imageblock" style=""><img alt="meme 2" src="images/meme-2.jpg" width="500px"></div>
   </section>
-  <section id="_i_have_no_background">
+  <section id="i_have_no_background">
     <h2>I have no background</h2>
   </section>
   <section>
@@ -18,30 +18,30 @@
   </section>
   <section data-background-image="images/70s.jpg" data-background-size="contain"></section>
   <section>
-    <section data-background-image="images/bio.jpg" data-background-size="100px" id="_hey">
+    <section data-background-image="images/bio.jpg" data-background-size="100px" id="hey">
       <h2>hey</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="200px" id="_here">
+    <section data-background-image="images/bio.jpg" data-background-size="200px" id="here">
       <h2>here</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="400px" id="_i">
+    <section data-background-image="images/bio.jpg" data-background-size="400px" id="i">
       <h2>I</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="800px" id="_come">
+    <section data-background-image="images/bio.jpg" data-background-size="800px" id="come">
       <h2>come</h2>
     </section>
   </section>
-  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="_url_goat">
+  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="url_goat">
     <h2>URL goat</h2>
   </section>
-  <section data-background-color="yellow" id="_no_yellow_regression">
+  <section data-background-color="yellow" id="no_yellow_regression">
     <h2>No [yellow] regression</h2>
   </section>
   <section>
-    <section id="_empty_vertical_top">
+    <section id="empty_vertical_top">
       <h2>Empty Vertical top</h2>
     </section>
-    <section data-background-image="images/70s.jpg" data-background-size="cover" id="_vertical_with_background">
+    <section data-background-image="images/70s.jpg" data-background-size="cover" id="vertical_with_background">
       <h2>Vertical with background</h2>
     </section>
   </section>

--- a/test/doctest/data-background-oldstyle.html
+++ b/test/doctest/data-background-oldstyle.html
@@ -7,7 +7,7 @@
   <section data-background-image="images/70s.jpg" data-background-size="cover">
     <div class="imageblock" style=""><img alt="meme 2" src="images/meme-2.jpg" width="500px"></div>
   </section>
-  <section id="_i_have_no_background">
+  <section id="i_have_no_background">
     <h2>I have no background</h2>
   </section>
   <section>
@@ -15,23 +15,23 @@
   </section>
   <section data-background-image="images/70s.jpg" data-background-size="contain"></section>
   <section>
-    <section data-background-image="images/bio.jpg" data-background-size="100px" id="_hey">
+    <section data-background-image="images/bio.jpg" data-background-size="100px" id="hey">
       <h2>hey</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="200px" id="_here">
+    <section data-background-image="images/bio.jpg" data-background-size="200px" id="here">
       <h2>here</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="400px" id="_i">
+    <section data-background-image="images/bio.jpg" data-background-size="400px" id="i">
       <h2>I</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="800px" id="_come">
+    <section data-background-image="images/bio.jpg" data-background-size="800px" id="come">
       <h2>come</h2>
     </section>
   </section>
-  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="_url_goat">
+  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="url_goat">
     <h2>URL Goat</h2>
   </section>
-  <section data-background-color="yellow" id="_no_yellow_regression">
+  <section data-background-color="yellow" id="no_yellow_regression">
     <h2>No [yellow] regression</h2>
   </section>
 </div>

--- a/test/doctest/document.html
+++ b/test/doctest/document.html
@@ -693,7 +693,7 @@
         <section class="title" data-state="title">
           <h1>Document Title</h1>
         </section>
-        <section id="_cavern_glow">
+        <section id="cavern_glow">
           <h2>Cavern Glow</h2>
         </section>
       </div>
@@ -803,7 +803,7 @@
         <section class="title" data-state="title">
           <h1>Document Title</h1>
         </section>
-        <section id="_cavern_glow">
+        <section id="cavern_glow">
           <h2>Cavern Glow</h2>
         </section>
       </div>

--- a/test/doctest/history-regression-tests.html
+++ b/test/doctest/history-regression-tests.html
@@ -3,17 +3,33 @@
   <section class="title" data-state="title">
     <h1>First Slide</h1>
   </section>
-  <section id="_second_slide">
+  <section id="second_slide">
     <h2>Second Slide</h2>
   </section>
-  <section id="_3rd_slide">
+  <section id="rd_slide">
     <h2>3rd Slide</h2>
   </section>
-  <section id="_p3rhaps_this_won_t_work">
+  <section id="p3rhaps_this_won_t_work">
     <h2>P3rhaps this won’t work</h2>
   </section>
-  <section id="_illegal_hrctr">
+  <section id="th_slide">
+    <h2>5th Slide</h2>
+  </section>
+  <section id="illegal_hrctr">
     <h2>Illegal çhàrâctérß</h2>
+  </section>
+  <section id="explicit">
+    <h2>Explicit section id</h2>
+  </section>
+  <section id="">
+    <h2>67848727</h2>
+  </section>
+  <section id="repeated_title">
+    <h2>Repeated title</h2>
+  </section>
+  <section></section>
+  <section id="repeated_title_2">
+    <h2>Repeated title</h2>
   </section>
 </div>
 <script src="reveal.js/lib/js/head.min.js"></script><script src="reveal.js/js/reveal.js"></script><script>

--- a/test/doctest/history.html
+++ b/test/doctest/history.html
@@ -3,19 +3,19 @@
   <section class="title" data-state="title">
     <h1>History</h1>
   </section>
-  <section id="_first_slide">
+  <section id="first_slide">
     <h2>First slide</h2>
     <div class="paragraph">
       <p>Uno</p>
     </div>
   </section>
-  <section id="_second_slide">
+  <section id="second_slide">
     <h2>Second slide</h2>
     <div class="paragraph">
       <p>Dos</p>
     </div>
   </section>
-  <section id="_third_slide">
+  <section id="third_slide">
     <h2>Third slide</h2>
     <div class="paragraph">
       <p>Tres</p>

--- a/test/doctest/images.html
+++ b/test/doctest/images.html
@@ -3,15 +3,15 @@
   <section class="title" data-state="title">
     <h1>Images tests</h1>
   </section>
-  <section id="_normal">
+  <section id="normal">
     <h2>Normal</h2>
     <div class="imageblock" style=""><img alt="web surfing time" src="images/web_surfing_time.gif"></div>
   </section>
-  <section id="_stretched">
+  <section id="stretched">
     <h2>Stretched</h2>
     <div class="imageblock stretch" style=""><img alt="web surfing time" height="100%" src="images/web_surfing_time.gif"></div>
   </section>
-  <section id="_hardcoded">
+  <section id="hardcoded">
     <h2>Hardcoded</h2>
     <div class="imageblock" style=""><img alt="web surfing time" src="images/web_surfing_time.gif" width="1200"></div>
   </section>

--- a/test/doctest/keyboard-shortcuts.html
+++ b/test/doctest/keyboard-shortcuts.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Keyboard shortcuts</h1>
   </section>
-  <section id="_some_shortcuts">
+  <section id="some_shortcuts">
     <h2>Some shortcuts</h2>
     <table class="tableblock frame-all grid-all" style="width: 100%;">
       <colgroup>

--- a/test/doctest/level-sections.html
+++ b/test/doctest/level-sections.html
@@ -3,14 +3,14 @@
   <section class="title" data-state="title">
     <h1>Levels</h1>
   </section>
-  <section id="_first_level">
+  <section id="first_level">
     <h2>First level</h2>
     <div class="paragraph">
       <p>First content</p>
     </div>
   </section>
   <section>
-    <section id="_vertical">
+    <section id="vertical">
       <h2>Vertical</h2>
       <div class="paragraph">
         <p>Vertical slides are using level 2 sections (<code>===</code>)</p>
@@ -19,28 +19,28 @@
         <p>Press down arrow.</p>
       </div>
     </section>
-    <section id="_level_3">
+    <section id="level_3">
       <h2>Level 3</h2>
       <div class="paragraph">
         <p>Level 3 (<code>====</code>), rendered as <code>&lt;h3&gt;</code> is now supported.</p>
       </div>
       <h3>Like this</h3>
     </section>
-    <section id="_deeper">
+    <section id="deeper">
       <h2>Deeper</h2>
       <h3>l3</h3>
       <h4>l4</h4>
       <h5>l5</h5>
     </section>
   </section>
-  <section id="_horizontal_slide">
+  <section id="horizontal_slide">
     <h2>Horizontal slide</h2>
     <h3>Also supports levels</h3>
     <div class="paragraph">
       <p>But they issue warnings during render</p>
     </div>
   </section>
-  <section id="_horizontal_sections">
+  <section id="horizontal_sections">
     <h2>Horizontal sections</h2>
     <h3>l3</h3>
     <h4>l4</h4>

--- a/test/doctest/multi-destination-content.html
+++ b/test/doctest/multi-destination-content.html
@@ -5,16 +5,16 @@
     <p class="author"><small>John Doe</small></p>
   </section>
   <section>
-    <section id="_main_section">
+    <section id="main_section">
       <h2>Main section</h2>
     </section>
-    <section id="_sub_section_lvl_2">
+    <section id="sub_section_lvl_2">
       <h2>Sub Section lvl 2</h2>
       <div class="paragraph">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sapien ex, elementum nec scelerisque id, condimentum nec nulla. Integer dignissim faucibus ullamcorper. Morbi eget mauris molestie, facilisis augue nec, vulputate metus. Ut volutpat risus lorem, id tempus ex egestas vel. Sed quis accumsan tellus. Suspendisse interdum augue vel augue rhoncus sodales. Ut at ultrices nulla. Sed id iaculis tellus. Pellentesque efficitur diam sit amet diam lobortis, in bibendum lectus ornare.</p>
       </div>
     </section>
-    <section id="_sub_section_lvl_3">
+    <section id="sub_section_lvl_3">
       <h2>Sub Section lvl 3</h2>
       <div class="paragraph">
         <p>Small<br>

--- a/test/doctest/outline.html
+++ b/test/doctest/outline.html
@@ -1,63 +1,63 @@
 <!-- .basic -->
-<section id="_section_1">
+<section id="section_1">
   <h2>Section 1</h2>
 </section>
 <section>
-  <section id="_section_2">
+  <section id="section_2">
     <h2>Section 2</h2>
   </section>
-  <section id="_section_2_1">
+  <section id="section_2_1">
     <h2>Section 2.1</h2>
     <h3>Section 2.1.1</h3>
   </section>
 </section>
-<section id="_section_3">
+<section id="section_3">
   <h2>Section 3</h2>
 </section>
 
 <!-- .toclevels -->
 <section>
-  <section id="_section_1">
+  <section id="section_1">
     <h2>Section 1</h2>
   </section>
-  <section id="_section_1_1">
+  <section id="section_1_1">
     <h2>Section 1.1</h2>
     <h3>Section 1.1.1</h3>
   </section>
 </section>
-<section id="_section_2">
+<section id="section_2">
   <h2>Section 2</h2>
 </section>
 
 <!-- .numbered -->
-<section id="_section_1">
+<section id="section_1">
   <h2>Section 1</h2>
 </section>
-<section id="_unnumbered_section">
+<section id="unnumbered_section">
   <h2>Unnumbered Section</h2>
 </section>
 <section>
-  <section id="_section_2">
+  <section id="section_2">
     <h2>Section 2</h2>
   </section>
-  <section id="_section_2_1">
+  <section id="section_2_1">
     <h2>Section 2.1</h2>
   </section>
 </section>
-<section id="_section_3">
+<section id="section_3">
   <h2>Section 3</h2>
 </section>
 
 <!-- .sectnumlevels -->
 <section>
-  <section id="_section_1">
+  <section id="section_1">
     <h2>Section 1</h2>
   </section>
-  <section id="_section_1_1">
+  <section id="section_1_1">
     <h2>Section 1.1</h2>
     <h3>Section 1.1.1</h3>
   </section>
 </section>
-<section id="_section_2">
+<section id="section_2">
   <h2>Section 2</h2>
 </section>

--- a/test/doctest/preamble.html
+++ b/test/doctest/preamble.html
@@ -1,5 +1,5 @@
 <!-- .basic -->
-<section id="_cavern_glow">
+<section id="cavern_glow">
   <h2>Cavern Glow</h2>
   <div class="paragraph">
     <p>The river rages through the cavern, rattling its content.</p>
@@ -7,7 +7,7 @@
 </section>
 
 <!-- .toc-placement-preamble -->
-<section id="_cavern_glow">
+<section id="cavern_glow">
   <h2>Cavern Glow</h2>
   <div class="paragraph">
     <p>The river rages through the cavern, rattling its content.</p>

--- a/test/doctest/revealjs-stretch.html
+++ b/test/doctest/revealjs-stretch.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Stretch class</h1>
   </section>
-  <section id="_first_slide">
+  <section id="first_slide">
     <h2>First slide</h2>
     <div class="paragraph">
       <p>Some content</p>
@@ -15,7 +15,7 @@
       <p>See?</p>
     </div>
   </section>
-  <section id="_second_slide">
+  <section id="second_slide">
     <h2>Second slide</h2>
     <div class="paragraph">
       <p>Some content</p>

--- a/test/doctest/section.html
+++ b/test/doctest/section.html
@@ -1,10 +1,10 @@
 <!-- .level1 -->
-<section id="_section_level_1">
+<section id="section_level_1">
   <h2>Section Level 1</h2>
 </section>
 
 <!-- .level2 -->
-<section id="_section_level_2">
+<section id="section_level_2">
   <h2>Section Level 2</h2>
 </section>
 
@@ -19,16 +19,16 @@
 
 <!-- .max-nesting -->
 <section>
-  <section id="_section_level_1">
+  <section id="section_level_1">
     <h2>Section Level 1</h2>
   </section>
-  <section id="_section_level_2">
+  <section id="section_level_2">
     <h2>Section Level 2</h2>
     <h3>Section Level 3</h3>
     <h4>Section Level 4</h4>
     <h5>Section Level 5</h5>
   </section>
-  <section id="_section_level_2_2">
+  <section id="section_level_2_2">
     <h2>Section Level 2</h2>
   </section>
 </section>
@@ -39,62 +39,62 @@
 </section>
 
 <!-- .with-roles -->
-<section class="center red" id="_section_title">
+<section class="center red" id="section_title">
   <h2>Section Title</h2>
 </section>
 
 <!-- .sectanchors -->
-<section id="_title_with_anchor">
+<section id="title_with_anchor">
   <h2>Title with anchor</h2>
 </section>
 
 <!-- .sectlinks -->
-<section id="_linked_title">
+<section id="linked_title">
   <h2>Linked title</h2>
 </section>
 
 <!-- .sectanchors-and-sectlinks -->
-<section id="_linked_title_with_anchor">
+<section id="linked_title_with_anchor">
   <h2>Linked title with anchor</h2>
 </section>
 
 <!-- .numbered -->
-<section id="_introduction_to_asciidoctor">
+<section id="introduction_to_asciidoctor">
   <h2>Introduction to Asciidoctor</h2>
 </section>
 <section>
-  <section id="_quick_starts">
+  <section id="quick_starts">
     <h2>Quick Starts</h2>
   </section>
-  <section id="_usage">
+  <section id="usage">
     <h2>Usage</h2>
     <h3>Using the Command Line Interface</h3>
     <h4>Processing Your Content</h4>
   </section>
-  <section id="_syntax">
+  <section id="syntax">
     <h2>Syntax</h2>
   </section>
 </section>
-<section id="_terms_and_concepts">
+<section id="terms_and_concepts">
   <h2>Terms and Concepts</h2>
 </section>
 
 <!-- .numbered-sectnumlevels-1 -->
-<section id="_introduction_to_asciidoctor">
+<section id="introduction_to_asciidoctor">
   <h2>Introduction to Asciidoctor</h2>
 </section>
 <section>
-  <section id="_quick_starts">
+  <section id="quick_starts">
     <h2>Quick Starts</h2>
   </section>
-  <section id="_usage">
+  <section id="usage">
     <h2>Usage</h2>
     <h3>Using the Command Line Interface</h3>
   </section>
-  <section id="_syntax">
+  <section id="syntax">
     <h2>Syntax</h2>
   </section>
 </section>
-<section id="_terms_and_concepts">
+<section id="terms_and_concepts">
   <h2>Terms and Concepts</h2>
 </section>

--- a/test/doctest/slide-state.html
+++ b/test/doctest/slide-state.html
@@ -3,16 +3,16 @@
   <section class="title" data-state="title">
     <h1>Title</h1>
   </section>
-  <section id="_first_slide">
+  <section id="first_slide">
     <h2>First slide</h2>
     <div class="paragraph">
       <p>Content</p>
     </div>
   </section>
-  <section data-background-color="white" data-state="title" id="_topic_slide">
+  <section data-background-color="white" data-state="title" id="topic_slide">
     <h2>Topic slide</h2>
   </section>
-  <section id="_second_slide">
+  <section id="second_slide">
     <h2>Second slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/source-callouts.html
+++ b/test/doctest/source-callouts.html
@@ -4,7 +4,7 @@
     <h1>Presentation</h1>
     <p class="author"><small>Me</small></p>
   </section>
-  <section id="_callout">
+  <section id="callout">
     <h2>Callout</h2>
     <div class="listingblock">
       <div class="content">

--- a/test/doctest/speaker-notes.html
+++ b/test/doctest/speaker-notes.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Title Slide</h1>
   </section>
-  <section id="_slide_one">
+  <section id="slide_one">
     <h2>Slide One</h2>
     <div class="ulist">
       <ul>
@@ -19,7 +19,7 @@
       </ul>
     </div>
   </section>
-  <section id="_slide_two">
+  <section id="slide_two">
     <h2>Slide Two</h2>
     <div class="paragraph">
       <p>Hello World - Good Bye Cruel World</p>

--- a/test/doctest/title-preamble.html
+++ b/test/doctest/title-preamble.html
@@ -9,7 +9,7 @@
     </div>
     <p class="author"><small>Author Name</small></p>
   </section>
-  <section id="_slide_2">
+  <section id="slide_2">
     <h2>Slide 2</h2>
   </section>
 </div>

--- a/test/doctest/title-slide-color.html
+++ b/test/doctest/title-slide-color.html
@@ -3,7 +3,7 @@
   <section class="title" data-background-color="red" data-state="title">
     <h1>EPIC TITLE</h1>
   </section>
-  <section id="_next_slide">
+  <section id="next_slide">
     <h2>Next slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/title-slide-image.html
+++ b/test/doctest/title-slide-image.html
@@ -3,7 +3,7 @@
   <section class="title" data-background-image="images/70s.jpg" data-state="title" data-transition="zoom" data-transition-speed="fast">
     <h1>EPIC TITLE</h1>
   </section>
-  <section id="_next_slide">
+  <section id="next_slide">
     <h2>Next slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/title-slide-video.html
+++ b/test/doctest/title-slide-video.html
@@ -3,7 +3,7 @@
   <section class="title" data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4" data-background-video-loop="true" data-background-video-muted="true" data-state="title">
     <h1>EPIC TITLE</h1>
   </section>
-  <section id="_next_slide">
+  <section id="next_slide">
     <h2>Next slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/title-subtitle-partitioning.html
+++ b/test/doctest/title-subtitle-partitioning.html
@@ -4,7 +4,7 @@
     <h1>Catch phrase</h1>
     <h2>Longer more explicit title introducing the real concept</h2>
   </section>
-  <section id="_slide_2">
+  <section id="slide_2">
     <h2>Slide 2</h2>
   </section>
 </div>

--- a/test/doctest/toc.html
+++ b/test/doctest/toc.html
@@ -1,5 +1,5 @@
 <!-- .basic -->
-<section id="_introduction">
+<section id="introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -15,16 +15,16 @@
   </div>
 </section>
 <section>
-  <section id="_the_ravages_of_writing">
+  <section id="the_ravages_of_writing">
     <h2>The Ravages of Writing</h2>
   </section>
-  <section id="_a_recipe_for_potion">
+  <section id="a_recipe_for_potion">
     <h2>A Recipe for Potion</h2>
   </section>
 </section>
 
 <!-- .with-title -->
-<section id="_introduction">
+<section id="introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -34,12 +34,12 @@
     </ol>
   </div>
 </section>
-<section id="_the_ravages_of_writing">
+<section id="the_ravages_of_writing">
   <h2>The Ravages of Writing</h2>
 </section>
 
 <!-- .with-levels -->
-<section id="_introduction">
+<section id="introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -55,16 +55,16 @@
   </div>
 </section>
 <section>
-  <section id="_the_ravages_of_writing">
+  <section id="the_ravages_of_writing">
     <h2>The Ravages of Writing</h2>
   </section>
-  <section id="_a_recipe_for_potion">
+  <section id="a_recipe_for_potion">
     <h2>A Recipe for Potion</h2>
   </section>
 </section>
 
 <!-- .with-id-and-role -->
-<section id="_introduction">
+<section id="introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -74,6 +74,6 @@
     </ol>
   </div>
 </section>
-<section id="_the_ravages_of_writing">
+<section id="the_ravages_of_writing">
   <h2>The Ravages of Writing</h2>
 </section>

--- a/test/doctest/transitions.html
+++ b/test/doctest/transitions.html
@@ -8,12 +8,12 @@
       <p>This</p>
     </div>
   </section>
-  <section data-transition="zoom" id="_zoom_zoom">
+  <section data-transition="zoom" id="zoom_zoom">
     <div class="paragraph">
       <p>This slide will override the presentation transition and zoom!</p>
     </div>
   </section>
-  <section data-transition-speed="fast" id="_speed">
+  <section data-transition-speed="fast" id="speed">
     <div class="paragraph">
       <p>Choose from three transition speeds: default, fast or slow!</p>
     </div>

--- a/test/doctest/vertical-slides.html
+++ b/test/doctest/vertical-slides.html
@@ -4,19 +4,19 @@
     <h1>Vertical Slides</h1>
   </section>
   <section>
-    <section id="_first_slide">
+    <section id="first_slide">
       <h2>First slide</h2>
       <div class="paragraph">
         <p>First content</p>
       </div>
     </section>
-    <section id="_vertical_1">
+    <section id="vertical_1">
       <h2>Vertical 1</h2>
       <div class="paragraph">
         <p>Content</p>
       </div>
     </section>
-    <section id="_vertical_2">
+    <section id="vertical_2">
       <h2>Vertical 2</h2>
       <div class="paragraph">
         <p>More content</p>
@@ -24,7 +24,7 @@
       <h3>Another level</h3>
     </section>
   </section>
-  <section id="_second_horizontal_slide">
+  <section id="second_horizontal_slide">
     <h2>Second horizontal slide</h2>
     <div class="paragraph">
       <p>And that is all folks</p>

--- a/test/doctest/video.html
+++ b/test/doctest/video.html
@@ -44,17 +44,17 @@
   <section class="title" data-state="title">
     <h1>Video tests</h1>
   </section>
-  <section id="_auto_sized">
+  <section id="auto_sized">
     <h2>Auto-sized</h2>
     <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
   </section>
-  <section id="_auto_sized_notitle">
+  <section id="auto_sized_notitle">
     <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
   </section>
-  <section data-background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&amp;start=3&amp;enablejsapi=1&amp;autoplay=1&amp;loop=1&amp;controls=0&amp;modestbranding=1" id="_background"></section>
-  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_video_file_named_attributes"></section>
-  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_video_file_options"></section>
-  <section id="_vimeo_autostart">
+  <section data-background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&amp;start=3&amp;enablejsapi=1&amp;autoplay=1&amp;loop=1&amp;controls=0&amp;modestbranding=1" id="background"></section>
+  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="video_file_named_attributes"></section>
+  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="video_file_options"></section>
+  <section id="vimeo_autostart">
     <h2>vimeo autostart</h2>
     <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" mozallowfullscreen="" src="https://player.vimeo.com/video/44878206" webkitallowfullscreen="" width="100%"></iframe></div>
   </section>


### PR DESCRIPTION
There were still some problems with the id stripping regex. I created a more extensive test case and made sure to pass all tests.

References:
* #127 
* #99 
* #75 
* hakimel/reveal.js#1346
* #32 
* https://github.com/hakimel/reveal.js/blob/360bc940062711db9b8020ce4e848f6c37014481/js/reveal.js