### PR TITLE
Rake examples:serve task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -98,6 +98,14 @@ namespace :examples do
       end
     end
   end
+
+  task :serve do
+    puts "View rendered examples at: http://127.0.0.1:5000/"
+    puts "Exit with Ctrl-C"
+    Dir.chdir('examples') do
+      `ruby -run -e httpd . -p 5000 -b 127.0.0.1`
+    end
+  end
 end
 
 task 'doctest:test' => 'prepare-converter'


### PR DESCRIPTION
Added a rake examples:serve task to quickly load and preview examples.

It loads a web server inside the examples/ dir. It doesn't depend on generation (task examples) or build because I didn't know how to do it and I wasn't sure it was necessary.

Created a PR so that people who know better than me can comment.