### PR TITLE
resolves #143, Upgrade to Asciidoctor.js 1.5.6-preview.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 npm-debug.log
 build/
 /dist/main.js
+/asciidoctor-reveal.js-*.tgz
 
 # ruby stuff
 /.bundle/

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -261,6 +261,10 @@ Then run:
  $ gem push asciidoctor-revealjs-X.Y.Z.gem
 
 . Check that the new version is available on https://rubygems.org/gems/asciidoctor-revealjs[rubygems.org]
+. Generate a compatible version of the Ruby converter (using opal mode)
++
+ $ bundle exec rake build:converter:opal
+
 . Build the node package (make sure you have `devDependencies` installed with: `npm install`):
 +
  $ npm run build

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -195,31 +195,33 @@ You can apply that label to a pull request that is complete and ready for review
 
 Makes triaging easier.
 
-
 == Node package
 
 === Test a local asciidoctor-reveal.js version
 
-In order to test the Node package, you need to create a test project adjacent to the clone of the `asciidoctor-reveal.js` repository:
+In order to test the Node package, you first need to create a tarball of the project using the command `npm pack`.
+This command will produce a file named `asciidoctor-reveal.js-<version>.tgz` in the working directory.
+
+Then, create a test project adjacent to the clone of the [.path]_asciidoctor-reveal.js_ repository:
 
  $ mkdir test-project
  $ cd test-project
 
-Now, install the dependencies.
+Now, install the dependencies from the tarball:
+
+ $ npm i --save ../asciidoctor-reveal.js/asciidoctor-reveal.js-<version>.tgz
+
+NOTE: The relative portion of the last command is where you are installing the local `asciidoctor-reveal.js` version from.
+
+Then proceed as documented in the `README.adoc`.
+
+=== Upgrade Asciidoctor.js version
 
 WARNING: It is important to track `Asciidoctor.js` and `bestikk-opal-compiler` versions together.
 The `opal-compiler` used to compile our node package must match `asciidoctor.js` `opal-runtime`.
 The former is explicitly installed by users on install and the later is specified in our `package.json`.
 When you update one remember to update the other.
 Versions known to work together can be found here, just replace <tag> with the `asciidoctor.js` release you are interested in: https://github.com/asciidoctor/asciidoctor.js/blob/<tag>/package.json
-
- $ npm i --save asciidoctor.js@1.5.6-preview.3
- $ npm i --save ../asciidoctor-reveal.js
-
-NOTE: The relative portion of the last command is where you are installing the local `asciidoctor-reveal.js` version from.
-
-Then proceed as documented in the `README.adoc`.
-
 
 == RubyGem package
 

--- a/README.adoc
+++ b/README.adoc
@@ -119,9 +119,6 @@ First you must install and configure {uri-nodejs-download}[Node.js] on your mach
 
 Using npm:
 
-// TODO once 1.1.0 is released, update this to: asciidoctor.js@1.5.6-preview.3 (or whichever fixes our current problems)
-
- $ npm i --save asciidoctor.js@1.5.5-5
  $ npm i --save asciidoctor-reveal.js
 
 === Rendering the AsciiDoc into slides

--- a/Rakefile
+++ b/Rakefile
@@ -13,16 +13,16 @@ namespace :build do
   require 'asciidoctor-templates-compiler'
   require 'slim-htag'
 
-  generator = if :mode == :opal
-    Temple::Generators::ArrayBuffer.new(freeze_static: false)
-  else
-    Temple::Generators::StringBuffer
-  end
-
   file CONVERTER_FILE, [:mode] => FileList["#{TEMPLATES_DIR}/*"] do |t, args|
     #require 'asciidoctor-templates-compiler'
     require_relative 'lib/asciidoctor-templates-compiler'
     require 'slim-htag'
+
+    generator = if args[:mode] == :opal
+      Temple::Generators::ArrayBuffer.new(freeze_static: false)
+    else
+     Temple::Generators::StringBuffer
+    end
 
     File.open(CONVERTER_FILE, 'w') do |file|
       $stderr.puts "Generating #{file.path}."
@@ -53,6 +53,11 @@ namespace :build do
     desc 'Compile Slim templates and generate converter.rb (fast mode)'
     task :fast do
       Rake::Task[CONVERTER_FILE].invoke
+    end
+
+    desc 'Compile Slim templates and generate converter.rb (opal mode)'
+    task :opal do
+      Rake::Task[CONVERTER_FILE].invoke(:opal)
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,65 +9,59 @@ require 'tilt'
 CONVERTER_FILE = 'lib/asciidoctor-revealjs/converter.rb'
 TEMPLATES_DIR = 'templates'
 
-namespace :build do
-  require 'asciidoctor-templates-compiler'
-  require 'slim-htag'
-
-  file CONVERTER_FILE, [:mode] => FileList["#{TEMPLATES_DIR}/*"] do |t, args|
-    #require 'asciidoctor-templates-compiler'
-    require_relative 'lib/asciidoctor-templates-compiler'
-    require 'slim-htag'
-
-    generator = if args[:mode] == :opal
-      Temple::Generators::ArrayBuffer.new(freeze_static: false)
-    else
-     Temple::Generators::StringBuffer
-    end
-
-    File.open(CONVERTER_FILE, 'w') do |file|
-      $stderr.puts "Generating #{file.path}."
-      Asciidoctor::TemplatesCompiler::RevealjsSlim.compile_converter(
-          templates_dir: TEMPLATES_DIR,
-          class_name: 'Asciidoctor::Revealjs::Converter',
-          register_for: ['revealjs'],
-          backend_info: {
-            basebackend: 'html',
-            outfilesuffix: '.html',
-            filetype: 'html',
-          },
-          delegate_backend: 'html5',
-          engine_opts: {
-            generator: generator,
-          },
-          pretty: (args[:mode] == :pretty),
-          output: file)
-    end
-  end
-
-  namespace :converter do
-    desc 'Compile Slim templates and generate converter.rb (pretty mode)'
-    task :pretty do
-      Rake::Task[CONVERTER_FILE].invoke(:pretty)
-    end
-
-    desc 'Compile Slim templates and generate converter.rb (fast mode)'
-    task :fast do
-      Rake::Task[CONVERTER_FILE].invoke
-    end
-
-    desc 'Compile Slim templates and generate converter.rb (opal mode)'
-    task :opal do
-      Rake::Task[CONVERTER_FILE].invoke(:opal)
-    end
-  end
-
-  task :converter => 'converter:pretty'
+file CONVERTER_FILE => FileList["#{TEMPLATES_DIR}/*"] do
+  build_converter :fast
 end
 
-task :build => 'build:converter:pretty'
+namespace :build do
+  desc 'Compile Slim templates and generate converter.rb'
+  task :converter => 'clean' do
+    build_converter
+  end
+
+  desc 'Compile Slim templates and generate converter.rb for Opal'
+  task 'converter:opal' => 'clean' do
+    build_converter :opal
+  end
+end
+
+task :build => 'build:converter'
 
 task :clean do
   rm_rf CONVERTER_FILE
+end
+
+def build_converter(mode = :pretty)
+  #require 'asciidoctor-templates-compiler'
+  require_relative 'lib/asciidoctor-templates-compiler'
+  require 'slim-htag'
+
+  generator = if mode == :opal
+    Temple::Generators::ArrayBuffer.new(freeze_static: false)
+  else
+    Temple::Generators::StringBuffer
+  end
+
+  File.open(CONVERTER_FILE, 'w') do |file|
+    puts "Generating #{file.path} (mode: #{mode})."
+
+    Asciidoctor::TemplatesCompiler::RevealjsSlim.compile_converter(
+      templates_dir: TEMPLATES_DIR,
+      class_name: 'Asciidoctor::Revealjs::Converter',
+      register_for: ['revealjs'],
+      backend_info: {
+        basebackend: 'html',
+        outfilesuffix: '.html',
+        filetype: 'html',
+      },
+      delegate_backend: 'html5',
+      engine_opts: {
+        generator: generator,
+      },
+      pretty: (mode == :pretty),
+      output: file
+    )
+  end
 end
 
 DocTest::RakeTasks.new do |t|
@@ -80,7 +74,7 @@ end
 task 'prepare-converter' do
   # Run as an external process to ensure that it will not affect tests
   # environment with extra loaded modules (especially slim).
-  `bundle exec rake build:converter:fast`
+  `bundle exec rake #{CONVERTER_FILE}`
 
   require_relative 'lib/asciidoctor-revealjs'
 end

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc!",
   "main": "dist/main.js",
   "engines": {
-    "node": ">=0.12",
+    "node": ">=4",
     "npm": ">=3.0.0"
   },
   "files": [
@@ -39,7 +39,8 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor-reveal.js",
   "dependencies": {
-    "reveal.js": "3.3.0"
+    "reveal.js": "3.3.0",
+    "asciidoctor.js": "1.5.6-preview.4"
   },
   "devDependencies": {
     "async": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "README.adoc"
   ],
   "scripts": {
-    "build": "node npm/build.js"
+    "build": "node npm/build.js",
+    "test": "node test/smoke.js"
   },
   "repository": {
     "type": "git",
@@ -43,10 +44,11 @@
     "asciidoctor.js": "1.5.6-preview.4"
   },
   "devDependencies": {
-    "async": "^1.5.0",
-    "bestikk-fs": "^0.1.0",
+    "async": "1.5.2",
+    "bestikk-fs": "0.1.0",
     "bestikk-log": "0.1.0",
-    "bestikk-opal-compiler": "0.3.0-integration7"
+    "bestikk-opal-compiler": "0.3.0-integration7",
+    "expect.js": "0.3.1"
   },
   "readme": "# Reveal.js converter for Asciidoctor\n\n[Asciidoctor reveal.js](https://github.com/asciidoctor/asciidoctor-reveal.js) is a converter for [Asciidoctor](https://github.com/asciidoctor/asciidoctor) and [Asciidoctor.js](https://github.com/asciidoctor/asciidoctor.js) that transforms an AsciiDoc document into an HTML5 presentation designed to be executed by the [reveal.js](http://lab.hakim.se/reveal-js/) presentation framework.\n\nThis is the npm module. For setup instructions and the AsciiDoc syntax to use to write a presentation see the module's documentation at [https://github.com/asciidoctor/asciidoctor-reveal.js](https://github.com/asciidoctor/asciidoctor-reveal.js).\n"
 }

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,0 +1,19 @@
+const asciidoctor = require('asciidoctor.js')();
+require('../dist/main.js');
+
+const expect = require('expect.js');
+
+const attributes = {'revealjsdir': 'node_modules/reveal.js@'};
+const options = {safe: 'safe', backend: 'revealjs', attributes: attributes, 'header_footer': true};
+const content = `= Title Slide
+
+== Slide One
+
+* Foo
+* Bar
+* World`;
+
+const result = asciidoctor.convert(content, options);
+
+expect(result).to.contain('<script src="node_modules/reveal.js/js/reveal.js">');
+expect(result).to.contain('<li><p>Foo</p></li>');


### PR DESCRIPTION
* Create a Rake task to generate a version of the Ruby converter which is compatible with Opal
* Add asciidoctor.js as a dependency
* Update HACKING and README accordingly


Resolves #143 
Ref #130