### PR TITLE
Added new examples and tests around source code listings

### DIFF
--- a/examples/source-callouts.adoc
+++ b/examples/source-callouts.adoc
@@ -2,14 +2,13 @@
 // Demonstration of source callouts
 // :include: //div[@class="slides"]
 // :header_footer:
-= Presentation
-Me
+= Source code callouts
 :icons: font
 :source-highlighter: highlightjs
-// FIXME coderay, pygments and rouge should also be tested
 
 == Callout
 
+// FIXME Callout with `:icons: font` not styled as a numbered ball (#168)
 [source, rust]
 ----
 fn main() {

--- a/examples/source-coderay.adoc
+++ b/examples/source-coderay.adoc
@@ -1,0 +1,33 @@
+// .source-coderay
+// Demonstration of source highlighting with coderay
+// :include: //div[@class="slides"]
+// :header_footer:
+= Source Code with Coderay
+:icons: font
+:source-highlighter: coderay
+:coderay-css: style
+
+== Requirements
+
+WARNING: This will not work from Asciidoctor.js
+
+[NOTE]
+====
+For this to work. You need to add:
+
+    gem 'coderay'
+
+to your `Gemfile` and re-run:
+
+    bundle install
+====
+
+== Use the Source
+
+[source, ruby]
+----
+# My first Ruby program
+# On my way to Ruby fame & fortune!
+
+puts 'Hello, world!'
+----

--- a/examples/source-highlightjs-html.adoc
+++ b/examples/source-highlightjs-html.adoc
@@ -1,0 +1,22 @@
+// .source-highlightjs-html
+// Avoiding regressions with HTML source code inside source block
+// :include: //div[@class="slides"]
+// :header_footer:
+= HTML Source Code with Highlight.JS
+:icons: font
+:source-highlighter: highlightjs
+
+== Use the Source
+
+[source, html]
+----
+<b>This should be source code and not bold</b>
+----
+
+== Callouts
+
+[source, html]
+----
+<b>complex code</b> <!--1-->
+----
+<1> complex code needs a callout

--- a/examples/source-highlightjs.adoc
+++ b/examples/source-highlightjs.adoc
@@ -1,0 +1,16 @@
+// .source-highlightjs
+// Demonstration of source highlighting with highlightjs
+// :include: //div[@class="slides"]
+// :header_footer:
+= Source Code with Highlight.JS
+:icons: font
+:source-highlighter: highlightjs
+
+== Use the Source
+
+[source, rust]
+----
+fn main() {
+    println!("Hello World!");
+}
+----

--- a/examples/source-prettify.adoc
+++ b/examples/source-prettify.adoc
@@ -1,0 +1,16 @@
+// .source-prettify
+// Demonstration of source highlighting with prettify
+// :include: //div[@class="slides"]
+// :header_footer:
+= Source Code with Prettify
+:icons: font
+:source-highlighter: prettify
+
+== Use the Source
+
+[source, rust]
+----
+fn main() {
+    println!("Hello World!");
+}
+----

--- a/examples/source-pygments.adoc
+++ b/examples/source-pygments.adoc
@@ -1,0 +1,32 @@
+// .source-pygments
+// Demonstration of source highlighting with pygments
+// :include: //div[@class="slides"]
+// :header_footer:
+= Source Code with Pygments
+:icons: font
+:source-highlighter: pygments
+:pygments-style: paraiso-dark
+
+== Requirements
+
+WARNING: This will not work from Asciidoctor.js
+
+[NOTE]
+====
+For this to work. You need to add:
+
+    gem 'pygments.rb'
+
+to your `Gemfile` and re-run:
+
+    bundle install
+====
+
+== Use the Source
+
+[source, rust]
+----
+fn main() {
+    println!("Hello World!");
+}
+----

--- a/test/doctest/source-callouts.html
+++ b/test/doctest/source-callouts.html
@@ -1,8 +1,7 @@
 <!-- .source-callouts -->
 <div class="slides">
   <section class="title" data-state="title">
-    <h1>Presentation</h1>
-    <p class="author"><small>Me</small></p>
+    <h1>Source code callouts</h1>
   </section>
   <section id="callout">
     <h2>Callout</h2>

--- a/test/doctest/source-highlightjs-html.html
+++ b/test/doctest/source-highlightjs-html.html
@@ -1,0 +1,32 @@
+<!-- .source-highlightjs-html -->
+<div class="slides">
+  <section class="title" data-state="title">
+    <h1>HTML Source Code with Highlight.JS</h1>
+  </section>
+  <section id="use_the_source">
+    <h2>Use the Source</h2>
+    <div class="listingblock">
+      <div class="content">
+        <pre class="highlight"><code class="html language-html" data-noescape="">&lt;b&gt;This should be source code and not bold&lt;/b&gt;</code></pre>
+      </div>
+    </div>
+  </section>
+  <section id="callouts">
+    <h2>Callouts</h2>
+    <div class="listingblock">
+      <div class="content">
+        <pre class="highlight"><code class="html language-html" data-noescape="">&lt;b&gt;complex code&lt;/b&gt; <i class="conum" data-value="1"></i><b>(1)</b></code></pre>
+      </div>
+    </div>
+    <div class="colist arabic">
+      <table>
+        <tr>
+          <td>
+            <i class="conum" data-value="1"></i><b>1</b>
+          </td>
+          <td>complex code needs a callout</td>
+        </tr>
+      </table>
+    </div>
+  </section>
+</div>

--- a/test/doctest/source-highlightjs.html
+++ b/test/doctest/source-highlightjs.html
@@ -1,0 +1,16 @@
+<!-- .source-highlightjs -->
+<div class="slides">
+  <section class="title" data-state="title">
+    <h1>Source Code with Highlight.JS</h1>
+  </section>
+  <section id="use_the_source">
+    <h2>Use the Source</h2>
+    <div class="listingblock">
+      <div class="content">
+        <pre class="highlight"><code class="rust language-rust" data-noescape="">fn main() {
+    println!("Hello World!");
+}</code></pre>
+      </div>
+    </div>
+  </section>
+</div>

--- a/test/doctest/source-prettify.html
+++ b/test/doctest/source-prettify.html
@@ -1,0 +1,16 @@
+<!-- .source-prettify -->
+<div class="slides">
+  <section class="title" data-state="title">
+    <h1>Source Code with Prettify</h1>
+  </section>
+  <section id="use_the_source">
+    <h2>Use the Source</h2>
+    <div class="listingblock">
+      <div class="content">
+        <pre class="prettyprint rust language-rust"><code>fn main() {
+    println!("Hello World!");
+}</code></pre>
+      </div>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
Related to #167 and #163. Only highlightjs is added to doctest otherwise we will need to add dependencies and I'm not fond of that given what we discussed in #163.