### PR TITLE
Adding converter.rb manually in gemspec. Fixes #172

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,9 @@ Enhancements::
 Compliance::
   * Code listing callouts now work properly ({uri-issue}166[#166], {uri-issue}167[#167])
 
+Bug fixes::
+  * The version 1.1.0 Ruby Gem was broken due to a packaging error ({uri-issue}172[#172])
+
 ////
 === Release meta
 

--- a/asciidoctor-revealjs.gemspec
+++ b/asciidoctor-revealjs.gemspec
@@ -14,7 +14,12 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   files = begin
-    (result = Open3.popen3('git ls-files -z') {|_, out| out.read }.split %(\0)).empty? ? Dir['**/*'] : result
+    if (result = Open3.popen3('git ls-files -z') {|_, out| out.read }.split %(\0)).empty?
+      Dir['**/*']
+    else
+      # converter.rb is built locally before packaging but ignored by git. Adding manually.
+      result + ['lib/asciidoctor-revealjs/converter.rb']
+    end
   rescue
     Dir['**/*']
   end


### PR DESCRIPTION
It's not the cleanest thing I've done in Ruby but it works. Reviewers, feel free to refer me to a solution better aligned with Asciidoctor's approach if you have one in mind.