### PR TITLE
Resolves #178, replace prepend method by a string concatenation

### DIFF
--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -53,7 +53,7 @@ module Slim::Helpers
       v = v.compact.join(' ') if v.is_a? Array
       attrs << (v == true ? k : %(#{k}="#{v}"))
     end
-    attrs_str = attrs.empty? ? '' : attrs.join(' ').prepend(' ')
+    attrs_str = attrs.empty? ? '' : ' ' + attrs.join(' ')
 
 
     if VOID_ELEMENTS.include? name.to_s


### PR DESCRIPTION
`prepend` method is not implemented in Opal and will throw an exception at runtime, when using Asciidoctor Reveal.js in a JavaScript environment.

I can confirm that the issue is fixed running the following command:

```
bundle exec rake build:converter:opal
npm run examples
```


Resolves #178