### PR TITLE
README: fix imagedir -> imagesdir attribute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -274,7 +274,7 @@ It sets reveal.js`' `data-background-image` attribute.
 The `size` attribute is also supported.
 See the {uri-revealjs-gh}#image-backgrounds[relevant reveal.js documentation] for details.
 
-NOTE: Background images file names are now relative to the `:imagedir:` attribute if set.
+NOTE: Background images file names are now relative to the `:imagesdir:` attribute if set.
 
 NOTE: The `canvas` keyword can be used instead of `background` for the same effect.
 


### PR DESCRIPTION
AsciiDoctor defines the `:imagesdir:` attribute, not `:imagedir:`, fixes this.