### PR TITLE
New speaker notes syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -195,15 +195,17 @@ Additional examples can be found in the AsciiDoc files (.adoc) in `examples/`.
 
 == Slide Two
 
-Hello World - Good Bye Cruel World
+A Great Story
 
-[NOTE.speaker]
+[.notes]
 --
-Actually things aren't that bad
+* tell anecdote
+* make a point
 --
 ----
 
 In previous snippet we are creating a slide titled Slide One with bullets and another one titled Slide Two with centered text (reveal.js`' default behavior) with {uri-revealjs-gh}#speaker-notes[speaker notes].
+Other syntax exists to create speaker notes, see `examples/speaker-notes.adoc`.
 
 Starting with Reveal.js 3.5 speaker notes supports configurable layouts:
 image:https://cloud.githubusercontent.com/assets/629429/21808439/b941eb52-d743-11e6-9936-44ef80c60580.gif[]

--- a/examples/speaker-notes.adoc
+++ b/examples/speaker-notes.adoc
@@ -13,9 +13,32 @@
 
 == Slide Two
 
-Hello World - Good Bye Cruel World
+Hello Speaker Notes
+
+[.notes]
+****
+* this is the new block type for speaker notes: sidebar
+* `notes` role required (written `.notes` in block attribute)
+* source is slightly more compact
+* and not tied to an admonition which can be useful in slides
+****
+
+== Slide Three
+
+Other speaker notes styles
+
+[.notes]
+--
+* Using open blocks work too
+* Yay!
+--
+
+== Slide Four
+
+Hello Old Style Speaker Notes
 
 [NOTE.speaker]
 --
-Actually things aren't that bad
+* notes using admonition block still work
+* `aside` or `notes` roles also valid in addition to `speaker`
 --

--- a/templates/admonition.html.slim
+++ b/templates/admonition.html.slim
@@ -1,6 +1,5 @@
-- if (has_role? 'aside') or (has_role? 'speaker')
-  aside.notes
-    =content
+- if (has_role? 'aside') or (has_role? 'speaker') or (has_role? 'notes')
+  include notes.html.slim
 - else
   .admonitionblock id=@id class=[(attr :name),role]
     table: tr

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -92,6 +92,20 @@ module Slim::Helpers
     end
   end
 
+
+  # Between delimiters (--) is code taken from asciidoctor-bespoke 1.0.0.alpha.1
+  # Licensed under MIT, Copyright (C) 2015-2016 Dan Allen and the Asciidoctor Project
+  #--
+  # Retrieve the converted content, wrap it in a `<p>` element if
+  # the content_model equals :simple and return the result.
+  #
+  # Returns the block content as a String, wrapped inside a `<p>` element if
+  # the content_model equals `:simple`.
+  def resolve_content
+    @content_model == :simple ? %(<p>#{content}</p>) : content
+  end
+  #--
+
 end
 
 # More custom functions can be added in another namespace if required

--- a/templates/notes.html.slim
+++ b/templates/notes.html.slim
@@ -1,0 +1,1 @@
+aside.notes =resolve_content

--- a/templates/open.html.slim
+++ b/templates/open.html.slim
@@ -9,7 +9,10 @@
 - elsif @style == 'partintro' && (@level != 0 || @parent.context != :section || @document.doctype != 'book')
   - puts 'asciidoctor: ERROR: partintro block can only be used when doctype is book and it\'s a child of a book part. Excluding block content.' 
 - else
-  .openblock id=@id class=[(@style != 'open' ? @style : nil),role]
-    - if title?
-      .title=title
-    .content=content
+  - if (has_role? 'aside') or (has_role? 'speaker') or (has_role? 'notes')
+    include notes.html.slim
+  - else
+    .openblock id=@id class=[(@style != 'open' ? @style : nil),role]
+      - if title?
+        .title=title
+      .content=content

--- a/templates/sidebar.html.slim
+++ b/templates/sidebar.html.slim
@@ -1,5 +1,8 @@
-.sidebarblock id=@id class=role
-  .content
-    - if title?
-      .title=title
-    =content
+- if (has_role? 'aside') or (has_role? 'speaker') or (has_role? 'notes')
+  include notes.html.slim
+- else
+  .sidebarblock id=@id class=role
+    .content
+      - if title?
+        .title=title
+      =content

--- a/test/doctest/speaker-notes.html
+++ b/test/doctest/speaker-notes.html
@@ -22,11 +22,60 @@
   <section id="slide_two">
     <h2>Slide Two</h2>
     <div class="paragraph">
-      <p>Hello World - Good Bye Cruel World</p>
+      <p>Hello Speaker Notes</p>
     </div>
     <aside class="notes">
-      <div class="paragraph">
-        <p>Actually things aren’t that bad</p>
+      <div class="ulist">
+        <ul>
+          <li>
+            <p>this is the new block type for speaker notes: sidebar</p>
+          </li>
+          <li>
+            <p><code>notes</code> role required (written <code>.notes</code> in block attribute)</p>
+          </li>
+          <li>
+            <p>source is slightly more compact</p>
+          </li>
+          <li>
+            <p>and not tied to an admonition which can be useful in slides</p>
+          </li>
+        </ul>
+      </div>
+    </aside>
+  </section>
+  <section id="slide_three">
+    <h2>Slide Three</h2>
+    <div class="paragraph">
+      <p>Other speaker notes styles</p>
+    </div>
+    <aside class="notes">
+      <div class="ulist">
+        <ul>
+          <li>
+            <p>Using open blocks work too</p>
+          </li>
+          <li>
+            <p>Yay!</p>
+          </li>
+        </ul>
+      </div>
+    </aside>
+  </section>
+  <section id="slide_four">
+    <h2>Slide Four</h2>
+    <div class="paragraph">
+      <p>Hello Old Style Speaker Notes</p>
+    </div>
+    <aside class="notes">
+      <div class="ulist">
+        <ul>
+          <li>
+            <p>notes using admonition block still work</p>
+          </li>
+          <li>
+            <p><code>aside</code> or <code>notes</code> roles also valid in addition to <code>speaker</code></p>
+          </li>
+        </ul>
       </div>
     </aside>
   </section>


### PR DESCRIPTION
Added a new `notes` role for speaker notes. Closely maps to upstream terminology. Also expanded valid note blocks to `open` and `sidebar` blocks (in addition to `admonition`).

`speaker` and `aside` roles are still working as valid speaker notes roles on the same block types as `notes`.

In other words, creating speaker notes is easier to remember now.

I did `sidebar` because of bespoke.