### PR TITLE
Clarified in docs and examples what's possible with floating and roles

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -495,7 +495,7 @@ Or
 See https://asciidoctor.org/docs/user-manual/#role[Asciidoctor's documentation] for more details.
 
 .Image specific note
-In addition to the https://asciidoctor.org/docs/user-manual/#positioning-attributes[existing attributes] to position images, roles can be used as well. However, the shorthand syntax (.) doesn't work in the image macro arguments but must be used above with the angle bracket syntax.
+In addition to the https://asciidoctor.org/docs/user-manual/\#positioning-attributes[existing attributes] to position images, roles can be used as well. However, the shorthand syntax (.) doesn't work in the image macro arguments but must be used above with the angle bracket syntax.
 See <<examples/images.adoc#,images.adoc>> for examples.
 
 Here is a list of supported roles:

--- a/README.adoc
+++ b/README.adoc
@@ -496,7 +496,7 @@ See https://asciidoctor.org/docs/user-manual/#role[Asciidoctor's documentation] 
 
 .Image specific note
 In addition to the https://asciidoctor.org/docs/user-manual/#positioning-attributes[existing attributes] to position images, roles can be used as well. However, the shorthand syntax (.) doesn't work in the image macro arguments but must be used above with the angle bracket syntax.
-See <<examples/images.adoc,images.adoc>> for examples.
+See <<examples/images.adoc#,images.adoc>> for examples.
 
 Here is a list of supported roles:
 

--- a/README.adoc
+++ b/README.adoc
@@ -468,6 +468,40 @@ Here is {uri-revealjs-gh}#markup[the relevant reveal.js
 documentation] on that topic.
 
 
+=== Asciidoctor-reveal.js specific roles
+
+Roles are usually applied with the following syntax where the `important-text` CSS class would be applied to the slide title in the generated HTML:
+
+[source, asciidoc]
+....
+[.important-text]
+== Slide Title
+
+* Some
+* Information
+....
+
+Or
+
+[source, asciidoc]
+....
+[role="important-text"]
+== Slide Title
+
+* Some
+* Information
+....
+
+See https://asciidoctor.org/docs/user-manual/#role[Asciidoctor's documentation] for more details.
+
+.Image specific note
+In addition to the https://asciidoctor.org/docs/user-manual/#positioning-attributes[existing attributes] to position images, roles can be used as well. However, the shorthand syntax (.) doesn't work in the image macro arguments but must be used above with the angle bracket syntax.
+See <<examples/images.adoc,images.adoc>> for examples.
+
+Here is a list of supported roles:
+
+right:: Will apply a `float: right` style to the affected block
+
 
 === Title slide customization
 

--- a/examples/images.adoc
+++ b/examples/images.adoc
@@ -18,6 +18,16 @@ image::web_surfing_time.gif[]
 
 image::web_surfing_time.gif[width="1200"]
 
+== Image Floating
+
+image::web_surfing_time.gif[width=400px,float=right]
+
+* Some
+* Points
+* You
+* Won't
+* Look At
+
 == Image Role Right
 
 // This is asciidoctor-revealjs specific, it allows you to put an image on the right even though it is not part of the same block
@@ -30,3 +40,12 @@ image::web_surfing_time.gif[role=right,width=400px]
 * You
 * Won't
 * Look At
+
+== Image Role Right [alt syntax]
+
+[.right]
+image::web_surfing_time.gif[alt text,width=400px]
+
+* Yup
+* That
+* Too

--- a/test/doctest/images.html
+++ b/test/doctest/images.html
@@ -15,6 +15,29 @@
     <h2>Hardcoded</h2>
     <div class="imageblock" style=""><img alt="web surfing time" src="images/web_surfing_time.gif" width="1200"></div>
   </section>
+  <section id="image_floating">
+    <h2>Image Floating</h2>
+    <div class="imageblock" style="float: right;"><img alt="web surfing time" src="images/web_surfing_time.gif" width="400px"></div>
+    <div class="ulist">
+      <ul>
+        <li>
+          <p>Some</p>
+        </li>
+        <li>
+          <p>Points</p>
+        </li>
+        <li>
+          <p>You</p>
+        </li>
+        <li>
+          <p>Won’t</p>
+        </li>
+        <li>
+          <p>Look At</p>
+        </li>
+      </ul>
+    </div>
+  </section>
   <section id="image_role_right">
     <h2>Image Role Right</h2>
     <div class="imageblock right" style=""><img alt="web surfing time" src="images/web_surfing_time.gif" width="400px"></div>
@@ -34,6 +57,23 @@
         </li>
         <li>
           <p>Look At</p>
+        </li>
+      </ul>
+    </div>
+  </section>
+  <section id="image_role_right_alt_syntax">
+    <h2>Image Role Right [alt syntax]</h2>
+    <div class="imageblock right" style=""><img alt="alt text" src="images/web_surfing_time.gif" width="400px"></div>
+    <div class="ulist">
+      <ul>
+        <li>
+          <p>Yup</p>
+        </li>
+        <li>
+          <p>That</p>
+        </li>
+        <li>
+          <p>Too</p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
New section about Asciidoctor-reveal.js specific roles, took the opportunity to introduce how roles are written in AsciiDoc and linked to upstream docs. Also took care of mentioning that image macro have a slightly different behavior.

Added examples (and tests) too.

Related to the just-added #213