### PR TITLE
Remove div nesting on listingblocks by default (fixes #195)

### DIFF
--- a/examples/source-callouts.adoc
+++ b/examples/source-callouts.adoc
@@ -16,3 +16,14 @@ fn main() {
 }
 ----
 <1> `println!` is a macro.
+
+== Stretched Callout
+
+[source, rust, role=stretch]
+----
+fn main() { // <1>
+    println!("Hello World!"); // <2>
+}
+----
+<1> `fn` for function
+<2> `println!` is a macro.

--- a/examples/source-highlightjs.adoc
+++ b/examples/source-highlightjs.adoc
@@ -14,3 +14,12 @@ fn main() {
     println!("Hello World!");
 }
 ----
+
+== Stretch the Source
+
+[source, rust, role="stretch"]
+----
+fn main() {
+    println!("Hello stretched World!");
+}
+----

--- a/templates/listing.html.slim
+++ b/templates/listing.html.slim
@@ -1,35 +1,35 @@
-.listingblock id=@id class=role
-  - if title?
-    .title=captioned_title
-  .content
-    - nowrap = !(@document.attr? :prewrap) || (option? 'nowrap')
-    / implicit listing blocks and source blocks are rendered as code
-    / explicit listing blocks stay listing
-    - if @style == 'source' || (@style == 'listing' && attributes[1] != 'listing')
-      - language = attr :language
-      - code_class = language ? [language, "language-#{language}"] : nil
-      - pre_class = ['highlight']
-      - pre_lang = nil
-      - code_noescape = false
-      - case attr 'source-highlighter'
-      - when 'coderay'
-        - pre_class = ['CodeRay']
-      - when 'pygments'
-        - pre_class = ['pygments','highlight']
-      - when 'prettify'
-        - pre_class = ['prettyprint']
-        - pre_class << 'linenums' if attr? :linenums
-        - pre_class << language if language
-        - pre_class << "language-#{language}" if language
-        - code_class = nil
-      - when 'html-pipeline'
-        - pre_lang = language
-        - pre_class = code_class = nil
-        - nowrap = false
-      - when 'highlightjs', 'highlight.js'
-        - code_noescape=true
-      - pre_class << 'nowrap' if nowrap
-      pre class=pre_class lang=pre_lang
-        code data-noescape=code_noescape class=code_class =content
-    - else
-      pre class=(nowrap ? 'nowrap' : nil) =content
+- if title?
+  .title=captioned_title
+- nowrap = !(@document.attr? :prewrap) || (option? 'nowrap')
+/ implicit listing blocks and source blocks are rendered as code
+/ explicit listing blocks stay listing
+- if @style == 'source' || (@style == 'listing' && attributes[1] != 'listing')
+  - language = attr :language
+  - code_class = language ? [language, "language-#{language}"] : nil
+  - pre_class = ['highlight']
+  - pre_lang = nil
+  - code_noescape = false
+  - case attr 'source-highlighter'
+  - when 'coderay'
+    - pre_class = ['CodeRay']
+  - when 'pygments'
+    - pre_class = ['pygments','highlight']
+  - when 'prettify'
+    - pre_class = ['prettyprint']
+    - pre_class << 'linenums' if attr? :linenums
+    - pre_class << language if language
+    - pre_class << "language-#{language}" if language
+    - code_class = nil
+  - when 'html-pipeline'
+    - pre_lang = language
+    - pre_class = code_class = nil
+    - nowrap = false
+  - when 'highlightjs', 'highlight.js'
+    - code_noescape=true
+  - pre_class << 'nowrap' if nowrap
+  - pre_class << 'listingblock'
+  - pre_class << role if role
+  pre class=pre_class lang=pre_lang id=@id
+    code data-noescape=code_noescape class=code_class =content
+- else
+  pre class=(nowrap ? 'nowrap' : nil) =content

--- a/test/doctest/colist.html
+++ b/test/doctest/colist.html
@@ -1,13 +1,9 @@
 <!-- .basic -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight"><code class="ruby language-ruby">require 'sinatra' <b>(1)</b>
+<pre class="highlight listingblock"><code class="ruby language-ruby">require 'sinatra' <b>(1)</b>
 
 get '/hi' do  <b>(2)</b>
   "Hello World!" <b>(3)</b>
 end</code></pre>
-  </div>
-</div>
 <div class="colist arabic">
   <ol>
     <li>
@@ -23,15 +19,11 @@ end</code></pre>
 </div>
 
 <!-- .with-title -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight"><code class="ruby language-ruby">require 'sinatra' <b>(1)</b>
+<pre class="highlight listingblock"><code class="ruby language-ruby">require 'sinatra' <b>(1)</b>
 
 get '/hi' do  <b>(2)</b>
   "Hello World!" <b>(3)</b>
 end</code></pre>
-  </div>
-</div>
 <div class="colist arabic">
   <div class="title">Description</div>
   <ol>
@@ -48,15 +40,11 @@ end</code></pre>
 </div>
 
 <!-- .with-id-and-role -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight"><code class="ruby language-ruby">require 'sinatra' <b>(1)</b>
+<pre class="highlight listingblock"><code class="ruby language-ruby">require 'sinatra' <b>(1)</b>
 
 get '/hi' do  <b>(2)</b>
   "Hello World!" <b>(3)</b>
 end</code></pre>
-  </div>
-</div>
 <div class="colist arabic sinatra" id="call">
   <ol>
     <li>

--- a/test/doctest/listing.html
+++ b/test/doctest/listing.html
@@ -1,70 +1,40 @@
 <!-- .basic -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight"><code>echo -n "Please enter your name: "
+<pre class="highlight listingblock"><code>echo -n "Please enter your name: "
 read name
 echo "Hello, $name!"</code></pre>
-  </div>
-</div>
 
 <!-- .basic-with-title -->
-<div class="listingblock">
-  <div class="title">Reading user input</div>
-  <div class="content">
-    <pre class="highlight"><code>echo -n "Please enter your name: "
+<div class="title">Reading user input</div>
+<pre class="highlight listingblock"><code>echo -n "Please enter your name: "
 read name
 echo "Hello, $name!"</code></pre>
-  </div>
-</div>
 
 <!-- .basic-nowrap -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight nowrap"><code>ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code></pre>
-  </div>
-</div>
+<pre class="highlight nowrap listingblock"><code>ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code></pre>
 
 <!-- .basic-with-id-and-role -->
-<div class="listingblock example" id="code">
-  <div class="content">
-    <pre class="highlight"><code>echo -n "Please enter your name: "
+<pre class="highlight listingblock example" id="code"><code>echo -n "Please enter your name: "
 read name
 echo "Hello, $name!"</code></pre>
-  </div>
-</div>
 
 <!-- .source -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight"><code>5.times do
+<pre class="highlight listingblock"><code>5.times do
   print "Odelay!"
 end</code></pre>
-  </div>
-</div>
 
 <!-- .source-with-title -->
-<div class="listingblock">
-  <div class="title">Odelay!</div>
-  <div class="content">
-    <pre class="highlight"><code>5.times do
+<div class="title">Odelay!</div>
+<pre class="highlight listingblock"><code>5.times do
   print "Odelay!"
 end</code></pre>
-  </div>
-</div>
 
 <!-- .source-with-language -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight"><code class="ruby language-ruby">5.times do
+<pre class="highlight listingblock"><code class="ruby language-ruby">5.times do
   print "Odelay!"
 end</code></pre>
-  </div>
-</div>
 
 <!-- .source-nowrap -->
-<div class="listingblock">
-  <div class="content">
-    <pre class="highlight nowrap"><code class="java language-java">public class ApplicationConfigurationProvider extends HttpConfigurationProvider {
+<pre class="highlight nowrap listingblock"><code class="java language-java">public class ApplicationConfigurationProvider extends HttpConfigurationProvider {
 
    public Configuration getConfiguration(ServletContext context) {
       return ConfigurationBuilder.begin()
@@ -74,5 +44,3 @@ end</code></pre>
                .where("path").matches(".*");
    }
 }</code></pre>
-  </div>
-</div>

--- a/test/doctest/multi-destination-content.html
+++ b/test/doctest/multi-destination-content.html
@@ -45,9 +45,7 @@
       <div class="paragraph">
         <p>Some overview</p>
       </div>
-      <div class="listingblock">
-        <div class="content">
-          <pre class="highlight"><code>+-------------------------------------------------+
+      <pre class="highlight listingblock"><code>+-------------------------------------------------+
 |       Big Picture                               |
 | +-------------+  +-----------+  +-------------+ |
 | |             |  |           |  |             | |
@@ -64,16 +62,12 @@
 | +-------------+  +-----------+  +-------------+ |
 |                                                 |
 +-------------------------------------------------+</code></pre>
-        </div>
-      </div>
     </section>
     <section>
       <div class="paragraph">
         <p>Detailed view</p>
       </div>
-      <div class="listingblock">
-        <div class="content">
-          <pre class="highlight"><code>+---------------------------------------------------+
+      <pre class="highlight listingblock"><code>+---------------------------------------------------+
 |   +---------------------------------------------+ |
 |   |     |      |             |                  | |
 |   |     |      |             |                  | |
@@ -82,8 +76,6 @@
 |   |     |      | DATA        |                  | |
 |   +---------------------------------------------+ |
 +---------------------------------------------------+</code></pre>
-        </div>
-      </div>
     </section>
   </section>
 </div>

--- a/test/doctest/source-callouts.html
+++ b/test/doctest/source-callouts.html
@@ -5,18 +5,38 @@
   </section>
   <section id="callout">
     <h2>Callout</h2>
-    <div class="listingblock">
-      <div class="content">
-        <pre class="highlight"><code class="rust language-rust" data-noescape="">fn main() {
+    <pre class="highlight listingblock"><code class="rust language-rust" data-noescape="">fn main() {
     println!("Hello World!"); <i class="conum" data-value="1"></i><b>(1)</b>
 }</code></pre>
-      </div>
-    </div>
     <div class="colist arabic">
       <table>
         <tr>
           <td>
             <i class="conum" data-value="1"></i><b>1</b>
+          </td>
+          <td>
+            <code>println!</code> is a macro.</td>
+        </tr>
+      </table>
+    </div>
+  </section>
+  <section id="stretched_callout">
+    <h2>Stretched Callout</h2>
+    <pre class="highlight listingblock stretch"><code class="rust language-rust" data-noescape="">fn main() { <i class="conum" data-value="1"></i><b>(1)</b>
+    println!("Hello World!"); <i class="conum" data-value="2"></i><b>(2)</b>
+}</code></pre>
+    <div class="colist arabic">
+      <table>
+        <tr>
+          <td>
+            <i class="conum" data-value="1"></i><b>1</b>
+          </td>
+          <td>
+            <code>fn</code> for function</td>
+        </tr>
+        <tr>
+          <td>
+            <i class="conum" data-value="2"></i><b>2</b>
           </td>
           <td>
             <code>println!</code> is a macro.</td>

--- a/test/doctest/source-highlightjs-html.html
+++ b/test/doctest/source-highlightjs-html.html
@@ -5,19 +5,11 @@
   </section>
   <section id="use_the_source">
     <h2>Use the Source</h2>
-    <div class="listingblock">
-      <div class="content">
-        <pre class="highlight"><code class="html language-html" data-noescape="">&lt;b&gt;This should be source code and not bold&lt;/b&gt;</code></pre>
-      </div>
-    </div>
+    <pre class="highlight listingblock"><code class="html language-html" data-noescape="">&lt;b&gt;This should be source code and not bold&lt;/b&gt;</code></pre>
   </section>
   <section id="callouts">
     <h2>Callouts</h2>
-    <div class="listingblock">
-      <div class="content">
-        <pre class="highlight"><code class="html language-html" data-noescape="">&lt;b&gt;complex code&lt;/b&gt; <i class="conum" data-value="1"></i><b>(1)</b></code></pre>
-      </div>
-    </div>
+    <pre class="highlight listingblock"><code class="html language-html" data-noescape="">&lt;b&gt;complex code&lt;/b&gt; <i class="conum" data-value="1"></i><b>(1)</b></code></pre>
     <div class="colist arabic">
       <table>
         <tr>

--- a/test/doctest/source-highlightjs.html
+++ b/test/doctest/source-highlightjs.html
@@ -5,12 +5,14 @@
   </section>
   <section id="use_the_source">
     <h2>Use the Source</h2>
-    <div class="listingblock">
-      <div class="content">
-        <pre class="highlight"><code class="rust language-rust" data-noescape="">fn main() {
+    <pre class="highlight listingblock"><code class="rust language-rust" data-noescape="">fn main() {
     println!("Hello World!");
 }</code></pre>
-      </div>
-    </div>
+  </section>
+  <section id="stretch_the_source">
+    <h2>Stretch the Source</h2>
+    <pre class="highlight listingblock stretch"><code class="rust language-rust" data-noescape="">fn main() {
+    println!("Hello stretched World!");
+}</code></pre>
   </section>
 </div>

--- a/test/doctest/source-prettify.html
+++ b/test/doctest/source-prettify.html
@@ -5,12 +5,8 @@
   </section>
   <section id="use_the_source">
     <h2>Use the Source</h2>
-    <div class="listingblock">
-      <div class="content">
-        <pre class="prettyprint rust language-rust"><code>fn main() {
+    <pre class="prettyprint rust language-rust listingblock"><code>fn main() {
     println!("Hello World!");
 }</code></pre>
-      </div>
-    </div>
   </section>
 </div>


### PR DESCRIPTION
With examples and doctest.

This might break user's customcss if they match on the nesting, we need to advise in release notes / changelog.