### PR TITLE
drop sudo: false from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 git:
   # use depth 2 just in case two refs get pushed at once (like a tag)
   depth: 2
@@ -26,6 +25,5 @@ script:
 - bundle exec rake build:js
 - npm run examples
 - npm test
-
 notifications:
   email: false


### PR DESCRIPTION
remove sudo: false (container-based infrastructure) as recommended by Travis

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration