### PR TITLE
Removed our custom ID stripping since upstream deals with them now

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -101,7 +101,7 @@ NOTE: For some reason, when you use the system Ruby on Fedora, you also have to 
 . Optional: Copy or clone reveal.js presentation framework.
   Allows you to modify themes or view slides offline.
 
-  $ git clone -b 3.6.0 --depth 1 https://github.com/hakimel/reveal.js.git
+  $ git clone -b 3.7.0 --depth 1 https://github.com/hakimel/reveal.js.git
 
 
 === Rendering the AsciiDoc into slides
@@ -112,7 +112,7 @@ NOTE: For some reason, when you use the system Ruby on Fedora, you also have to 
 . Generate HTML presentation from the AsciiDoc source
 
   $ bundle exec asciidoctor-revealjs \
-    -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.6.0 CONTENT_FILE.adoc
+    -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0 CONTENT_FILE.adoc
 
 . If you did the optional step of having a local reveal.js clone you can
   convert AsciiDoc source with
@@ -698,7 +698,7 @@ Default is built-in [path]_lib/css/zenburn.css_.
 |<file\|URL>
 |Overrides reveal.js directory.
 Example: ../reveal.js or
-https://cdnjs.com/libraries/reveal.js/3.6.0[https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.6.0].
+https://cdnjs.com/libraries/reveal.js/3.7.0[https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0].
 Default is `reveal.js/` unless in a Node.js environment where it is `node_modules/reveal.js/`.
 
 |:revealjs_controls:

--- a/examples/history-regression-tests.adoc
+++ b/examples/history-regression-tests.adoc
@@ -19,8 +19,14 @@
 
 == Illegal çhàrâctérß
 
-[[explicit]]
+[[explicit_with_anchor]]
 == Explicit section id
+
+[id=explicit_with_id]
+== Another Explicit Section Id
+
+[#explicit_with_short_anchor]
+== 3rd Explicit is the Charm
 
 == 67848727
 // Everything should be stripped in the id
@@ -32,3 +38,7 @@
 
 == Repeated title
 // Exact same title means exact same id
+
+== hello こんにちは
+
+== hello 你好

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/asciidoctor/asciidoctor-reveal.js",
   "dependencies": {
     "asciidoctor.js": "1.5.6",
-    "reveal.js": "3.6.0"
+    "reveal.js": "3.7.0"
   },
   "devDependencies": {
     "bestikk-log": "0.1.0",

--- a/templates/section.html.slim
+++ b/templates/section.html.slim
@@ -1,10 +1,4 @@
 / OPTIONS PROCESSING
-/ strip IDs the same way revealjs does to make links to direct slides work using URL fragments gh#127
-/ Strip unallowed characters globally then strip anything non a-Z from start of string until something matches
-/ TODO remove when hakimel/reveal.js#1230 is fixed
-- _id = id.gsub(/[^a-zA-Z0-9\-\_\:\.]/, '').gsub(/^[^a-zA-Z]+/, '')
-
-
 / hide slides on %conceal, %notitle and named "!"
 - titleless = (title = self.title) == '!'
 - hide_title = (titleless || (option? :notitle) || (option? :conceal))
@@ -43,7 +37,7 @@
 - if @level == 1 && !vertical_slides.empty?
   section
     / TODO: try to get rid of duplication w/ standalone slide section
-    section(id=(titleless ? nil : _id)
+    section(id=(titleless ? nil : id)
       class=roles
       data-transition=(attr 'transition')
       data-transition-speed=(attr 'transition-speed')
@@ -72,7 +66,7 @@
     h level=(@level) =title
     =content.chomp
   - else
-    section(id=(titleless ? nil : _id)
+    section(id=(titleless ? nil : id)
       class=roles
       data-transition=(attr 'transition')
       data-transition-speed=(attr 'transition-speed')

--- a/test/doctest/admonitions-icons.html
+++ b/test/doctest/admonitions-icons.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Admonitions</h1>
   </section>
-  <section id="admonition">
+  <section id="_admonition">
     <h2>Admonition</h2>
     <div class="admonitionblock important">
       <table>
@@ -16,7 +16,7 @@
       </table>
     </div>
   </section>
-  <section id="admonition_block">
+  <section id="_admonition_block">
     <h2>Admonition block</h2>
     <div class="admonitionblock warning">
       <table>
@@ -33,7 +33,7 @@
       </table>
     </div>
   </section>
-  <section id="admonition_block_complex">
+  <section id="_admonition_block_complex">
     <h2>Admonition block complex</h2>
     <div class="admonitionblock note">
       <table>
@@ -61,7 +61,7 @@
       </table>
     </div>
   </section>
-  <section id="admonition_with_caption">
+  <section id="_admonition_with_caption">
     <h2>Admonition with caption</h2>
     <div class="admonitionblock tip">
       <table>

--- a/test/doctest/admonitions.html
+++ b/test/doctest/admonitions.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Admonitions</h1>
   </section>
-  <section id="admonition">
+  <section id="_admonition">
     <h2>Admonition</h2>
     <div class="admonitionblock important">
       <table>
@@ -14,7 +14,7 @@
       </table>
     </div>
   </section>
-  <section id="admonition_block">
+  <section id="_admonition_block">
     <h2>Admonition block</h2>
     <div class="admonitionblock warning">
       <table>
@@ -29,7 +29,7 @@
       </table>
     </div>
   </section>
-  <section id="admonition_block_complex">
+  <section id="_admonition_block_complex">
     <h2>Admonition block complex</h2>
     <div class="admonitionblock note">
       <table>
@@ -55,7 +55,7 @@
       </table>
     </div>
   </section>
-  <section id="admonition_with_caption">
+  <section id="_admonition_with_caption">
     <h2>Admonition with caption</h2>
     <div class="admonitionblock tip">
       <table>

--- a/test/doctest/background-color.html
+++ b/test/doctest/background-color.html
@@ -3,16 +3,16 @@
   <section class="title" data-state="title">
     <h1>Colorful Presentation</h1>
   </section>
-  <section data-background-color="yellow" id="hello">
+  <section data-background-color="yellow" id="_hello">
     <h2>Hello</h2>
   </section>
-  <section class="red background" id="here">
+  <section class="red background" id="_here">
     <h2>Here</h2>
     <div class="paragraph">
       <p>Red</p>
     </div>
   </section>
-  <section class="green" id="we">
+  <section class="green" id="_we">
     <h2>We</h2>
     <div class="paragraph">
       <p>Green</p>
@@ -26,19 +26,19 @@
       </table>
     </div>
   </section>
-  <section class="blue canvas" id="go">
+  <section class="blue canvas" id="_go">
     <h2>Go</h2>
     <div class="paragraph">
       <p>Blue</p>
     </div>
   </section>
-  <section class="topic" id="default_color">
+  <section class="topic" id="_default_color">
     <h2>Default color</h2>
     <div class="paragraph">
       <p>but fancy font</p>
     </div>
   </section>
-  <section class="topic red background" id="fancy_font">
+  <section class="topic red background" id="_fancy_font">
     <h2>fancy font</h2>
     <div class="paragraph">
       <p>and color!</p>

--- a/test/doctest/concealed-slide-titles.html
+++ b/test/doctest/concealed-slide-titles.html
@@ -8,12 +8,12 @@
       <p>This</p>
     </div>
   </section>
-  <section id="presentation">
+  <section id="_presentation">
     <div class="paragraph">
       <p>presentation’s titles</p>
     </div>
   </section>
-  <section id="concealed">
+  <section id="_concealed">
     <div class="paragraph">
       <p>should be concealed</p>
     </div>

--- a/test/doctest/customcss.html
+++ b/test/doctest/customcss.html
@@ -4,7 +4,7 @@
     <h1>Custom CSS</h1>
     <p class="author"><small>Author</small></p>
   </section>
-  <section id="slide_1">
+  <section id="_slide_1">
     <h2>Slide 1</h2>
   </section>
 </div>

--- a/test/doctest/data-background-newstyle.html
+++ b/test/doctest/data-background-newstyle.html
@@ -3,14 +3,14 @@
   <section class="title" data-state="title">
     <h1>Test slide deck</h1>
   </section>
-  <section data-background-image="images/cover.jpg" data-background-size="cover" id="opening"></section>
-  <section data-background-image="images/cover.jpg" data-background-size="cover" id="canvas">
+  <section data-background-image="images/cover.jpg" data-background-size="cover" id="_opening"></section>
+  <section data-background-image="images/cover.jpg" data-background-size="cover" id="_canvas">
     <h2>canvas</h2>
   </section>
   <section data-background-image="images/70s.jpg" data-background-size="cover">
     <div class="imageblock" style=""><img alt="meme 2" src="images/meme-2.jpg" width="500px"></div>
   </section>
-  <section id="i_have_no_background">
+  <section id="_i_have_no_background">
     <h2>I have no background</h2>
   </section>
   <section>
@@ -18,30 +18,30 @@
   </section>
   <section data-background-image="images/70s.jpg" data-background-size="contain"></section>
   <section>
-    <section data-background-image="images/bio.jpg" data-background-size="100px" id="hey">
+    <section data-background-image="images/bio.jpg" data-background-size="100px" id="_hey">
       <h2>hey</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="200px" id="here">
+    <section data-background-image="images/bio.jpg" data-background-size="200px" id="_here">
       <h2>here</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="400px" id="i">
+    <section data-background-image="images/bio.jpg" data-background-size="400px" id="_i">
       <h2>I</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="800px" id="come">
+    <section data-background-image="images/bio.jpg" data-background-size="800px" id="_come">
       <h2>come</h2>
     </section>
   </section>
-  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="url_goat">
+  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="_url_goat">
     <h2>URL goat</h2>
   </section>
-  <section data-background-color="yellow" id="no_yellow_regression">
+  <section data-background-color="yellow" id="_no_yellow_regression">
     <h2>No [yellow] regression</h2>
   </section>
   <section>
-    <section id="empty_vertical_top">
+    <section id="_empty_vertical_top">
       <h2>Empty Vertical top</h2>
     </section>
-    <section data-background-image="images/70s.jpg" data-background-size="cover" id="vertical_with_background">
+    <section data-background-image="images/70s.jpg" data-background-size="cover" id="_vertical_with_background">
       <h2>Vertical with background</h2>
     </section>
   </section>

--- a/test/doctest/data-background-oldstyle.html
+++ b/test/doctest/data-background-oldstyle.html
@@ -7,7 +7,7 @@
   <section data-background-image="images/70s.jpg" data-background-size="cover">
     <div class="imageblock" style=""><img alt="meme 2" src="images/meme-2.jpg" width="500px"></div>
   </section>
-  <section id="i_have_no_background">
+  <section id="_i_have_no_background">
     <h2>I have no background</h2>
   </section>
   <section>
@@ -15,23 +15,23 @@
   </section>
   <section data-background-image="images/70s.jpg" data-background-size="contain"></section>
   <section>
-    <section data-background-image="images/bio.jpg" data-background-size="100px" id="hey">
+    <section data-background-image="images/bio.jpg" data-background-size="100px" id="_hey">
       <h2>hey</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="200px" id="here">
+    <section data-background-image="images/bio.jpg" data-background-size="200px" id="_here">
       <h2>here</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="400px" id="i">
+    <section data-background-image="images/bio.jpg" data-background-size="400px" id="_i">
       <h2>I</h2>
     </section>
-    <section data-background-image="images/bio.jpg" data-background-size="800px" id="come">
+    <section data-background-image="images/bio.jpg" data-background-size="800px" id="_come">
       <h2>come</h2>
     </section>
   </section>
-  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="url_goat">
+  <section data-background-image="https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg" data-background-size="contain" id="_url_goat">
     <h2>URL Goat</h2>
   </section>
-  <section data-background-color="yellow" id="no_yellow_regression">
+  <section data-background-color="yellow" id="_no_yellow_regression">
     <h2>No [yellow] regression</h2>
   </section>
 </div>

--- a/test/doctest/document.html
+++ b/test/doctest/document.html
@@ -1017,7 +1017,7 @@
         <section class="title" data-state="title">
           <h1>Document Title</h1>
         </section>
-        <section id="cavern_glow">
+        <section id="_cavern_glow">
           <h2>Cavern Glow</h2>
         </section>
       </div>
@@ -1178,7 +1178,7 @@
         <section class="title" data-state="title">
           <h1>Document Title</h1>
         </section>
-        <section id="cavern_glow">
+        <section id="_cavern_glow">
           <h2>Cavern Glow</h2>
         </section>
       </div>

--- a/test/doctest/embedded.html
+++ b/test/doctest/embedded.html
@@ -17,11 +17,11 @@
 </div>
 
 <!-- .toc -->
-<section id="cavern_glow">
+<section id="_cavern_glow">
   <h2>Cavern Glow</h2>
 </section>
 
 <!-- .toc-title -->
-<section id="cavern_glow">
+<section id="_cavern_glow">
   <h2>Cavern Glow</h2>
 </section>

--- a/test/doctest/history-regression-tests.html
+++ b/test/doctest/history-regression-tests.html
@@ -3,33 +3,45 @@
   <section class="title" data-state="title">
     <h1>First Slide</h1>
   </section>
-  <section id="second_slide">
+  <section id="_second_slide">
     <h2>Second Slide</h2>
   </section>
-  <section id="rd_slide">
+  <section id="_3rd_slide">
     <h2>3rd Slide</h2>
   </section>
-  <section id="p3rhaps_this_will_not_work">
+  <section id="_p3rhaps_this_will_not_work">
     <h2>P3rhaps this will not work</h2>
   </section>
-  <section id="th_slide">
+  <section id="_5th_slide">
     <h2>5th Slide</h2>
   </section>
-  <section id="illegal_hrctr">
+  <section id="_illegal_çhàrâctérß">
     <h2>Illegal çhàrâctérß</h2>
   </section>
-  <section id="explicit">
+  <section id="explicit_with_anchor">
     <h2>Explicit section id</h2>
   </section>
-  <section id="">
+  <section id="explicit_with_id">
+    <h2>Another Explicit Section Id</h2>
+  </section>
+  <section id="explicit_with_short_anchor">
+    <h2>3rd Explicit is the Charm</h2>
+  </section>
+  <section id="_67848727">
     <h2>67848727</h2>
   </section>
-  <section id="repeated_title">
+  <section id="_repeated_title">
     <h2>Repeated title</h2>
   </section>
   <section></section>
-  <section id="repeated_title_2">
+  <section id="_repeated_title_2">
     <h2>Repeated title</h2>
+  </section>
+  <section id="_hello_こんにちは">
+    <h2>hello こんにちは</h2>
+  </section>
+  <section id="_hello_你好">
+    <h2>hello 你好</h2>
   </section>
 </div>
 <script src="reveal.js/lib/js/head.min.js"></script><script src="reveal.js/js/reveal.js"></script><script>

--- a/test/doctest/history.html
+++ b/test/doctest/history.html
@@ -3,19 +3,19 @@
   <section class="title" data-state="title">
     <h1>History</h1>
   </section>
-  <section id="first_slide">
+  <section id="_first_slide">
     <h2>First slide</h2>
     <div class="paragraph">
       <p>Uno</p>
     </div>
   </section>
-  <section id="second_slide">
+  <section id="_second_slide">
     <h2>Second slide</h2>
     <div class="paragraph">
       <p>Dos</p>
     </div>
   </section>
-  <section id="third_slide">
+  <section id="_third_slide">
     <h2>Third slide</h2>
     <div class="paragraph">
       <p>Tres</p>

--- a/test/doctest/images.html
+++ b/test/doctest/images.html
@@ -3,19 +3,19 @@
   <section class="title" data-state="title">
     <h1>Images tests</h1>
   </section>
-  <section id="normal">
+  <section id="_normal">
     <h2>Normal</h2>
     <div class="imageblock" style=""><img alt="web surfing time" src="images/web_surfing_time.gif"></div>
   </section>
-  <section id="stretched">
+  <section id="_stretched">
     <h2>Stretched</h2>
     <div class="imageblock stretch" style=""><img alt="web surfing time" height="100%" src="images/web_surfing_time.gif"></div>
   </section>
-  <section id="hardcoded">
+  <section id="_hardcoded">
     <h2>Hardcoded</h2>
     <div class="imageblock" style=""><img alt="web surfing time" src="images/web_surfing_time.gif" width="1200"></div>
   </section>
-  <section id="image_floating">
+  <section id="_image_floating">
     <h2>Image Floating</h2>
     <div class="imageblock" style="float: right;"><img alt="web surfing time" src="images/web_surfing_time.gif" width="400px"></div>
     <div class="ulist">
@@ -38,7 +38,7 @@
       </ul>
     </div>
   </section>
-  <section id="image_role_right">
+  <section id="_image_role_right">
     <h2>Image Role Right</h2>
     <div class="imageblock right" style=""><img alt="web surfing time" src="images/web_surfing_time.gif" width="400px"></div>
     <div class="ulist">
@@ -61,7 +61,7 @@
       </ul>
     </div>
   </section>
-  <section id="image_role_right_alt_syntax">
+  <section id="_image_role_right_alt_syntax">
     <h2>Image Role Right [alt syntax]</h2>
     <div class="imageblock right" style=""><img alt="alt text" src="images/web_surfing_time.gif" width="400px"></div>
     <div class="ulist">

--- a/test/doctest/keyboard-shortcuts.html
+++ b/test/doctest/keyboard-shortcuts.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Keyboard shortcuts</h1>
   </section>
-  <section id="some_shortcuts">
+  <section id="_some_shortcuts">
     <h2>Some shortcuts</h2>
     <table class="tableblock frame-all grid-all" style="width: 100%;">
       <colgroup>

--- a/test/doctest/level-sections.html
+++ b/test/doctest/level-sections.html
@@ -3,14 +3,14 @@
   <section class="title" data-state="title">
     <h1>Levels</h1>
   </section>
-  <section id="first_level">
+  <section id="_first_level">
     <h2>First level</h2>
     <div class="paragraph">
       <p>First content</p>
     </div>
   </section>
   <section>
-    <section id="vertical">
+    <section id="_vertical">
       <h2>Vertical</h2>
       <div class="paragraph">
         <p>Vertical slides are using level 2 sections (<code>===</code>)</p>
@@ -19,28 +19,28 @@
         <p>Press down arrow.</p>
       </div>
     </section>
-    <section id="level_3">
+    <section id="_level_3">
       <h2>Level 3</h2>
       <div class="paragraph">
         <p>Level 3 (<code>====</code>), rendered as <code>&lt;h3&gt;</code> is now supported.</p>
       </div>
       <h3>Like this</h3>
     </section>
-    <section id="deeper">
+    <section id="_deeper">
       <h2>Deeper</h2>
       <h3>l3</h3>
       <h4>l4</h4>
       <h5>l5</h5>
     </section>
   </section>
-  <section id="horizontal_slide">
+  <section id="_horizontal_slide">
     <h2>Horizontal slide</h2>
     <h3>Also supports levels</h3>
     <div class="paragraph">
       <p>But they issue warnings during render</p>
     </div>
   </section>
-  <section id="horizontal_sections">
+  <section id="_horizontal_sections">
     <h2>Horizontal sections</h2>
     <h3>l3</h3>
     <h4>l4</h4>

--- a/test/doctest/multi-destination-content.html
+++ b/test/doctest/multi-destination-content.html
@@ -5,16 +5,16 @@
     <p class="author"><small>John Doe</small></p>
   </section>
   <section>
-    <section id="main_section">
+    <section id="_main_section">
       <h2>Main section</h2>
     </section>
-    <section id="sub_section_lvl_2">
+    <section id="_sub_section_lvl_2">
       <h2>Sub Section lvl 2</h2>
       <div class="paragraph">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sapien ex, elementum nec scelerisque id, condimentum nec nulla. Integer dignissim faucibus ullamcorper. Morbi eget mauris molestie, facilisis augue nec, vulputate metus. Ut volutpat risus lorem, id tempus ex egestas vel. Sed quis accumsan tellus. Suspendisse interdum augue vel augue rhoncus sodales. Ut at ultrices nulla. Sed id iaculis tellus. Pellentesque efficitur diam sit amet diam lobortis, in bibendum lectus ornare.</p>
       </div>
     </section>
-    <section id="sub_section_lvl_3">
+    <section id="_sub_section_lvl_3">
       <h2>Sub Section lvl 3</h2>
       <div class="paragraph">
         <p>Small<br>

--- a/test/doctest/outline.html
+++ b/test/doctest/outline.html
@@ -1,63 +1,63 @@
 <!-- .basic -->
-<section id="section_1">
+<section id="_section_1">
   <h2>Section 1</h2>
 </section>
 <section>
-  <section id="section_2">
+  <section id="_section_2">
     <h2>Section 2</h2>
   </section>
-  <section id="section_2_1">
+  <section id="_section_2_1">
     <h2>Section 2.1</h2>
     <h3>Section 2.1.1</h3>
   </section>
 </section>
-<section id="section_3">
+<section id="_section_3">
   <h2>Section 3</h2>
 </section>
 
 <!-- .toclevels -->
 <section>
-  <section id="section_1">
+  <section id="_section_1">
     <h2>Section 1</h2>
   </section>
-  <section id="section_1_1">
+  <section id="_section_1_1">
     <h2>Section 1.1</h2>
     <h3>Section 1.1.1</h3>
   </section>
 </section>
-<section id="section_2">
+<section id="_section_2">
   <h2>Section 2</h2>
 </section>
 
 <!-- .numbered -->
-<section id="section_1">
+<section id="_section_1">
   <h2>Section 1</h2>
 </section>
-<section id="unnumbered_section">
+<section id="_unnumbered_section">
   <h2>Unnumbered Section</h2>
 </section>
 <section>
-  <section id="section_2">
+  <section id="_section_2">
     <h2>Section 2</h2>
   </section>
-  <section id="section_2_1">
+  <section id="_section_2_1">
     <h2>Section 2.1</h2>
   </section>
 </section>
-<section id="section_3">
+<section id="_section_3">
   <h2>Section 3</h2>
 </section>
 
 <!-- .sectnumlevels -->
 <section>
-  <section id="section_1">
+  <section id="_section_1">
     <h2>Section 1</h2>
   </section>
-  <section id="section_1_1">
+  <section id="_section_1_1">
     <h2>Section 1.1</h2>
     <h3>Section 1.1.1</h3>
   </section>
 </section>
-<section id="section_2">
+<section id="_section_2">
   <h2>Section 2</h2>
 </section>

--- a/test/doctest/preamble.html
+++ b/test/doctest/preamble.html
@@ -1,5 +1,5 @@
 <!-- .basic -->
-<section id="cavern_glow">
+<section id="_cavern_glow">
   <h2>Cavern Glow</h2>
   <div class="paragraph">
     <p>The river rages through the cavern, rattling its content.</p>
@@ -7,7 +7,7 @@
 </section>
 
 <!-- .toc-placement-preamble -->
-<section id="cavern_glow">
+<section id="_cavern_glow">
   <h2>Cavern Glow</h2>
   <div class="paragraph">
     <p>The river rages through the cavern, rattling its content.</p>

--- a/test/doctest/revealjs-features.html
+++ b/test/doctest/revealjs-features.html
@@ -4,26 +4,26 @@
     <h1>Reveal.JS</h1>
   </section>
   <section>
-    <section id="slide_one">
+    <section id="_slide_one">
       <h2>Slide One</h2>
       <div class="paragraph">
         <p>Some content</p>
       </div>
     </section>
-    <section id="and">
+    <section id="_and">
       <h2>And</h2>
       <div class="paragraph">
         <p>With Reveal.JS 3.6</p>
       </div>
     </section>
-    <section id="fragments">
+    <section id="_fragments">
       <h2>Fragments</h2>
       <div class="paragraph">
         <p>Can now be displayed in URLs</p>
       </div>
     </section>
   </section>
-  <section id="second_slide">
+  <section id="_second_slide">
     <h2>Second slide</h2>
     <div class="paragraph">
       <p>Done</p>

--- a/test/doctest/revealjs-plugin-activation.html
+++ b/test/doctest/revealjs-plugin-activation.html
@@ -4,13 +4,13 @@
     <h1>Default Plugins Changes</h1>
     <p class="author"><small>Author</small></p>
   </section>
-  <section id="slide_1">
+  <section id="_slide_1">
     <h2>Slide 1</h2>
     <div class="paragraph">
       <p>Content 1</p>
     </div>
   </section>
-  <section id="slide_2">
+  <section id="_slide_2">
     <h2>Slide 2</h2>
     <div class="paragraph">
       <p>Content 2</p>

--- a/test/doctest/revealjs-plugins.html
+++ b/test/doctest/revealjs-plugins.html
@@ -4,13 +4,13 @@
     <h1>Custom Plugins</h1>
     <p class="author"><small>Author</small></p>
   </section>
-  <section id="slide_1">
+  <section id="_slide_1">
     <h2>Slide 1</h2>
     <div class="paragraph">
       <p>Content 1</p>
     </div>
   </section>
-  <section id="slide_2">
+  <section id="_slide_2">
     <h2>Slide 2</h2>
     <div class="paragraph">
       <p>Content 2</p>

--- a/test/doctest/revealjs-stretch.html
+++ b/test/doctest/revealjs-stretch.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Stretch class</h1>
   </section>
-  <section id="first_slide">
+  <section id="_first_slide">
     <h2>First slide</h2>
     <div class="paragraph">
       <p>Some content</p>
@@ -15,7 +15,7 @@
       <p>See?</p>
     </div>
   </section>
-  <section id="second_slide">
+  <section id="_second_slide">
     <h2>Second slide</h2>
     <div class="paragraph">
       <p>Some content</p>

--- a/test/doctest/section.html
+++ b/test/doctest/section.html
@@ -1,10 +1,10 @@
 <!-- .level1 -->
-<section id="section_level_1">
+<section id="_section_level_1">
   <h2>Section Level 1</h2>
 </section>
 
 <!-- .level2 -->
-<section id="section_level_2">
+<section id="_section_level_2">
   <h2>Section Level 2</h2>
 </section>
 
@@ -19,16 +19,16 @@
 
 <!-- .max-nesting -->
 <section>
-  <section id="section_level_1">
+  <section id="_section_level_1">
     <h2>Section Level 1</h2>
   </section>
-  <section id="section_level_2">
+  <section id="_section_level_2">
     <h2>Section Level 2</h2>
     <h3>Section Level 3</h3>
     <h4>Section Level 4</h4>
     <h5>Section Level 5</h5>
   </section>
-  <section id="section_level_2_2">
+  <section id="_section_level_2_2">
     <h2>Section Level 2</h2>
   </section>
 </section>
@@ -39,70 +39,70 @@
 </section>
 
 <!-- .with-roles -->
-<section class="center red" id="section_title">
+<section class="center red" id="_section_title">
   <h2>Section Title</h2>
 </section>
 
 <!-- .sectanchors -->
-<section id="title_with_anchor">
+<section id="_title_with_anchor">
   <h2>Title with anchor</h2>
 </section>
 
 <!-- .sectlinks -->
-<section id="linked_title">
+<section id="_linked_title">
   <h2>Linked title</h2>
 </section>
 
 <!-- .sectanchors-and-sectlinks -->
-<section id="linked_title_with_anchor">
+<section id="_linked_title_with_anchor">
   <h2>Linked title with anchor</h2>
 </section>
 
 <!-- .numbered -->
-<section id="introduction_to_asciidoctor">
+<section id="_introduction_to_asciidoctor">
   <h2>Introduction to Asciidoctor</h2>
 </section>
 <section>
-  <section id="quick_starts">
+  <section id="_quick_starts">
     <h2>Quick Starts</h2>
   </section>
-  <section id="usage">
+  <section id="_usage">
     <h2>Usage</h2>
     <h3>Using the Command Line Interface</h3>
     <h4>Processing Your Content</h4>
   </section>
-  <section id="syntax">
+  <section id="_syntax">
     <h2>Syntax</h2>
   </section>
 </section>
-<section id="terms_and_concepts">
+<section id="_terms_and_concepts">
   <h2>Terms and Concepts</h2>
 </section>
 
 <!-- .numbered-sectnumlevels-1 -->
-<section id="introduction_to_asciidoctor">
+<section id="_introduction_to_asciidoctor">
   <h2>Introduction to Asciidoctor</h2>
 </section>
 <section>
-  <section id="quick_starts">
+  <section id="_quick_starts">
     <h2>Quick Starts</h2>
   </section>
-  <section id="usage">
+  <section id="_usage">
     <h2>Usage</h2>
     <h3>Using the Command Line Interface</h3>
   </section>
-  <section id="syntax">
+  <section id="_syntax">
     <h2>Syntax</h2>
   </section>
 </section>
-<section id="terms_and_concepts">
+<section id="_terms_and_concepts">
   <h2>Terms and Concepts</h2>
 </section>
 
 <!-- .book-part-title -->
-<section id="part_title">
+<section id="_part_title">
   <h2>Part Title</h2>
-  <section id="section_level_1">
+  <section id="_section_level_1">
     <h2>Section Level 1</h2>
   </section>
 </section>

--- a/test/doctest/slide-state.html
+++ b/test/doctest/slide-state.html
@@ -3,16 +3,16 @@
   <section class="title" data-state="title">
     <h1>Title</h1>
   </section>
-  <section id="first_slide">
+  <section id="_first_slide">
     <h2>First slide</h2>
     <div class="paragraph">
       <p>Content</p>
     </div>
   </section>
-  <section data-background-color="white" data-state="title" id="topic_slide">
+  <section data-background-color="white" data-state="title" id="_topic_slide">
     <h2>Topic slide</h2>
   </section>
-  <section id="second_slide">
+  <section id="_second_slide">
     <h2>Second slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/source-callouts.html
+++ b/test/doctest/source-callouts.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Source code callouts</h1>
   </section>
-  <section id="callout">
+  <section id="_callout">
     <h2>Callout</h2>
     <pre class="highlight listingblock"><code class="rust language-rust" data-noescape="">fn main() {
     println!("Hello World!"); <i class="conum" data-value="1"></i><b>(1)</b>
@@ -20,7 +20,7 @@
       </table>
     </div>
   </section>
-  <section id="stretched_callout">
+  <section id="_stretched_callout">
     <h2>Stretched Callout</h2>
     <pre class="highlight listingblock stretch"><code class="rust language-rust" data-noescape="">fn main() { <i class="conum" data-value="1"></i><b>(1)</b>
     println!("Hello World!"); <i class="conum" data-value="2"></i><b>(2)</b>

--- a/test/doctest/source-highlightjs-html.html
+++ b/test/doctest/source-highlightjs-html.html
@@ -3,11 +3,11 @@
   <section class="title" data-state="title">
     <h1>HTML Source Code with Highlight.JS</h1>
   </section>
-  <section id="use_the_source">
+  <section id="_use_the_source">
     <h2>Use the Source</h2>
     <pre class="highlight listingblock"><code class="html language-html" data-noescape="">&lt;b&gt;This should be source code and not bold&lt;/b&gt;</code></pre>
   </section>
-  <section id="callouts">
+  <section id="_callouts">
     <h2>Callouts</h2>
     <pre class="highlight listingblock"><code class="html language-html" data-noescape="">&lt;b&gt;complex code&lt;/b&gt; <i class="conum" data-value="1"></i><b>(1)</b></code></pre>
     <div class="colist arabic">

--- a/test/doctest/source-highlightjs.html
+++ b/test/doctest/source-highlightjs.html
@@ -3,13 +3,13 @@
   <section class="title" data-state="title">
     <h1>Source Code with Highlight.JS</h1>
   </section>
-  <section id="use_the_source">
+  <section id="_use_the_source">
     <h2>Use the Source</h2>
     <pre class="highlight listingblock"><code class="rust language-rust" data-noescape="">fn main() {
     println!("Hello World!");
 }</code></pre>
   </section>
-  <section id="stretch_the_source">
+  <section id="_stretch_the_source">
     <h2>Stretch the Source</h2>
     <pre class="highlight listingblock stretch"><code class="rust language-rust" data-noescape="">fn main() {
     println!("Hello stretched World!");

--- a/test/doctest/source-prettify.html
+++ b/test/doctest/source-prettify.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Source Code with Prettify</h1>
   </section>
-  <section id="use_the_source">
+  <section id="_use_the_source">
     <h2>Use the Source</h2>
     <pre class="prettyprint rust language-rust listingblock"><code>fn main() {
     println!("Hello World!");

--- a/test/doctest/speaker-notes.html
+++ b/test/doctest/speaker-notes.html
@@ -3,7 +3,7 @@
   <section class="title" data-state="title">
     <h1>Title Slide</h1>
   </section>
-  <section id="slide_one">
+  <section id="_slide_one">
     <h2>Slide One</h2>
     <div class="ulist">
       <ul>
@@ -19,7 +19,7 @@
       </ul>
     </div>
   </section>
-  <section id="slide_two">
+  <section id="_slide_two">
     <h2>Slide Two</h2>
     <div class="paragraph">
       <p>Hello Speaker Notes</p>
@@ -43,7 +43,7 @@
       </div>
     </aside>
   </section>
-  <section id="slide_three">
+  <section id="_slide_three">
     <h2>Slide Three</h2>
     <div class="paragraph">
       <p>Other speaker notes styles</p>
@@ -61,7 +61,7 @@
       </div>
     </aside>
   </section>
-  <section id="slide_four">
+  <section id="_slide_four">
     <h2>Slide Four</h2>
     <div class="paragraph">
       <p>Hello Old Style Speaker Notes</p>

--- a/test/doctest/theme-custom.html
+++ b/test/doctest/theme-custom.html
@@ -4,13 +4,13 @@
   <section class="title" data-state="title">
     <h1>OWASP Theme</h1>
   </section>
-  <section class="topic" data-background-color="#da291c" id="a_ctf_wtf_is_that">
+  <section class="topic" data-background-color="#da291c" id="_a_ctf_wtf_is_that">
     <h2>A CTF, WTF is that?</h2>
   </section>
-  <section class="topic" data-background-color="black" id="ctf_capture_the_flags">
+  <section class="topic" data-background-color="black" id="_ctf_capture_the_flags">
     <h2>CTF ⇒ Capture The Flags</h2>
   </section>
-  <section id="actually_they_are">
+  <section id="_actually_they_are">
     <h2>Actually, they are…​</h2>
     <div class="ulist">
       <ul>

--- a/test/doctest/title-preamble.html
+++ b/test/doctest/title-preamble.html
@@ -9,7 +9,7 @@
     </div>
     <p class="author"><small>Author Name</small></p>
   </section>
-  <section id="slide_2">
+  <section id="_slide_2">
     <h2>Slide 2</h2>
   </section>
 </div>

--- a/test/doctest/title-slide-color.html
+++ b/test/doctest/title-slide-color.html
@@ -3,7 +3,7 @@
   <section class="title" data-background-color="red" data-state="title">
     <h1>EPIC TITLE</h1>
   </section>
-  <section id="next_slide">
+  <section id="_next_slide">
     <h2>Next slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/title-slide-image.html
+++ b/test/doctest/title-slide-image.html
@@ -3,7 +3,7 @@
   <section class="title" data-background-image="images/70s.jpg" data-state="title" data-transition="zoom" data-transition-speed="fast">
     <h1>EPIC TITLE</h1>
   </section>
-  <section id="next_slide">
+  <section id="_next_slide">
     <h2>Next slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/title-slide-video.html
+++ b/test/doctest/title-slide-video.html
@@ -3,7 +3,7 @@
   <section class="title" data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4" data-background-video-loop="true" data-background-video-muted="true" data-state="title">
     <h1>EPIC TITLE</h1>
   </section>
-  <section id="next_slide">
+  <section id="_next_slide">
     <h2>Next slide</h2>
     <div class="paragraph">
       <p>Content</p>

--- a/test/doctest/title-subtitle-partitioning.html
+++ b/test/doctest/title-subtitle-partitioning.html
@@ -4,7 +4,7 @@
     <h1>Catch phrase</h1>
     <h2>Longer more explicit title introducing the real concept</h2>
   </section>
-  <section id="slide_2">
+  <section id="_slide_2">
     <h2>Slide 2</h2>
   </section>
 </div>

--- a/test/doctest/toc.html
+++ b/test/doctest/toc.html
@@ -24,7 +24,7 @@
 </section>
 
 <!-- .with-title -->
-<section id="introduction">
+<section id="_introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -34,12 +34,12 @@
     </ol>
   </div>
 </section>
-<section id="the_ravages_of_writing">
+<section id="_the_ravages_of_writing">
   <h2>The Ravages of Writing</h2>
 </section>
 
 <!-- .with-levels -->
-<section id="introduction">
+<section id="_introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -55,16 +55,16 @@
   </div>
 </section>
 <section>
-  <section id="the_ravages_of_writing">
+  <section id="_the_ravages_of_writing">
     <h2>The Ravages of Writing</h2>
   </section>
-  <section id="a_recipe_for_potion">
+  <section id="_a_recipe_for_potion">
     <h2>A Recipe for Potion</h2>
   </section>
 </section>
 
 <!-- .with-id-and-role -->
-<section id="introduction">
+<section id="_introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -74,12 +74,12 @@
     </ol>
   </div>
 </section>
-<section id="the_ravages_of_writing">
+<section id="_the_ravages_of_writing">
   <h2>The Ravages of Writing</h2>
 </section>
 
 <!-- .in-section -->
-<section id="introduction">
+<section id="_introduction">
   <h2>Introduction</h2>
   <div class="toc" id="toc">
     <div id="toctitle">Table of Contents</div>
@@ -95,20 +95,20 @@
   </div>
 </section>
 <section>
-  <section id="the_ravages_of_writing">
+  <section id="_the_ravages_of_writing">
     <h2>The Ravages of Writing</h2>
   </section>
-  <section id="a_recipe_for_potion">
+  <section id="_a_recipe_for_potion">
     <h2>A Recipe for Potion</h2>
   </section>
 </section>
 
 <!-- .in-preamble -->
 <section>
-  <section id="the_ravages_of_writing">
+  <section id="_the_ravages_of_writing">
     <h2>The Ravages of Writing</h2>
   </section>
-  <section id="a_recipe_for_potion">
+  <section id="_a_recipe_for_potion">
     <h2>A Recipe for Potion</h2>
   </section>
 </section>

--- a/test/doctest/transitions.html
+++ b/test/doctest/transitions.html
@@ -8,12 +8,12 @@
       <p>This</p>
     </div>
   </section>
-  <section data-transition="zoom" id="zoom_zoom">
+  <section data-transition="zoom" id="_zoom_zoom">
     <div class="paragraph">
       <p>This slide will override the presentation transition and zoom!</p>
     </div>
   </section>
-  <section data-transition-speed="fast" id="speed">
+  <section data-transition-speed="fast" id="_speed">
     <div class="paragraph">
       <p>Choose from three transition speeds: default, fast or slow!</p>
     </div>

--- a/test/doctest/vertical-slides.html
+++ b/test/doctest/vertical-slides.html
@@ -4,19 +4,19 @@
     <h1>Vertical Slides</h1>
   </section>
   <section>
-    <section id="first_slide">
+    <section id="_first_slide">
       <h2>First slide</h2>
       <div class="paragraph">
         <p>First content</p>
       </div>
     </section>
-    <section id="vertical_1">
+    <section id="_vertical_1">
       <h2>Vertical 1</h2>
       <div class="paragraph">
         <p>Content</p>
       </div>
     </section>
-    <section id="vertical_2">
+    <section id="_vertical_2">
       <h2>Vertical 2</h2>
       <div class="paragraph">
         <p>More content</p>
@@ -24,7 +24,7 @@
       <h3>Another level</h3>
     </section>
   </section>
-  <section id="second_horizontal_slide">
+  <section id="_second_horizontal_slide">
     <h2>Second horizontal slide</h2>
     <div class="paragraph">
       <p>And that is all folks</p>

--- a/test/doctest/video.html
+++ b/test/doctest/video.html
@@ -44,17 +44,17 @@
   <section class="title" data-state="title">
     <h1>Video tests</h1>
   </section>
-  <section id="auto_sized">
+  <section id="_auto_sized">
     <h2>Auto-sized</h2>
     <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
   </section>
-  <section id="auto_sized_notitle">
+  <section id="_auto_sized_notitle">
     <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
   </section>
-  <section data-background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&amp;start=3&amp;enablejsapi=1&amp;autoplay=1&amp;loop=1&amp;controls=0&amp;modestbranding=1" id="background"></section>
-  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="video_file_named_attributes"></section>
-  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="video_file_options"></section>
-  <section id="vimeo_autostart">
+  <section data-background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&amp;start=3&amp;enablejsapi=1&amp;autoplay=1&amp;loop=1&amp;controls=0&amp;modestbranding=1" id="_background"></section>
+  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_video_file_named_attributes"></section>
+  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_video_file_options"></section>
+  <section id="_vimeo_autostart">
     <h2>vimeo autostart</h2>
     <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" mozallowfullscreen="" src="https://player.vimeo.com/video/44878206" webkitallowfullscreen="" width="100%"></iframe></div>
   </section>


### PR DESCRIPTION
Fixes #192 but also removes our workaround in #150.

Test cases from #192 were added.

Will impact links because the prepending of `_` is reintroduced on automatically generated links (Asciidoctor's behavior) so CHANGELOG will be explicit about that.