### PR TITLE
Travis: Added Ruby 2.6 as a target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ git:
 language: ruby
 node_js: lts/*
 rvm:
+- 2.6
 - 2.5
 - 2.4
 - 2.3

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -47,6 +47,7 @@ Enhancements::
 Compliance::
   * AsciiDoc source callout icons now work ({uri-issue}54[#54], {uri-issue}168[#168], {uri-issue}224[#224])
   * New reveal.js 3.7.0 features supported: the new `slideNumber` formats and `showSlideNumber` configuration parameter are now supported ({uri-issue}212[#212], {uri-issue}239[#239])
+  * Asciidoctor 2.0 ready ({uri-issue}245[#245])
 
 Bug Fixes::
   * Reveal.js' `stretch` class now works with listing blocks ({uri-issue}195[#195], {uri-issue}223[#223])


### PR DESCRIPTION
Adding ruby 2.6 and once our 2.0 is released, we will drop older rubies following upstream Asciidoctor's plan.