### PR TITLE
Drop verse table cells and fix tests

### DIFF
--- a/templates/table.html.slim
+++ b/templates/table.html.slim
@@ -21,7 +21,7 @@ table(id=@id class=['tableblock',"frame-#{attr :frame, 'all'}","grid-#{attr :gri
                 - cell_content = cell.text
               - else
                 - case cell.style
-                - when :verse, :literal
+                - when :literal
                   - cell_content = cell.text
                 - else
                   - cell_content = cell.content
@@ -35,8 +35,6 @@ table(id=@id class=['tableblock',"frame-#{attr :frame, 'all'}","grid-#{attr :gri
                   - case cell.style
                   - when :asciidoc
                     div=cell_content
-                  - when :verse
-                    .verse=cell_content
                   - when :literal
                     .literal: pre=cell_content
                   - when :header

--- a/test/doctest/table.html
+++ b/test/doctest/table.html
@@ -339,7 +339,7 @@
         <p class="tableblock"><strong>Strong text</strong></p>
       </td>
       <td class="tableblock halign-left valign-top">
-        <div class="verse">Verse block</div>
+        <p class="tableblock">Verse block</p>
       </td>
     </tr>
   </tbody>
@@ -508,7 +508,7 @@
     </tr>
     <tr>
       <td class="tableblock halign-left valign-top">
-        <div class="verse">This cell contains a verse that may one day expound on the wonders of tables in an epic sonnet.</div>
+        <p class="tableblock">This cell contains a verse that may one day expound on the wonders of tables in an epic sonnet.</p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Removed verse table cells support and tests to keep builds happy.

Asciidoctor 2.0.0 is dropping verse table cells and nobody will miss them. See https://github.com/asciidoctor/asciidoctor/issues/3111 for workarounds if you need one.