### PR TITLE
Dropping Ruby 2.1 and 2.2 (End of Life)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ rvm:
 - 2.5
 - 2.4
 - 2.3
-- 2.2
-- 2.1
 - jruby-9k
 gemfile:
 - Gemfile


### PR DESCRIPTION
Will merge only once I know I'm doing a feature release. Don't want to drop support on a bugfix release.