### PR TITLE
Document further revealjs_* options in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -677,7 +677,7 @@ Here are details about Asciidoctor's http://asciidoctor.org/docs/user-manual/#ad
 == Reveal.js Options
 
 There are some attributes that can be set at the top of the document which they are specific of `revealjs` converter.
-They are applied in the link:templates/document.html.slim[document template]
+They are applied in the link:templates/document.html.slim[document template].
 
 NOTE: Default settings are based on `reveal.js` default settings.
 

--- a/README.adoc
+++ b/README.adoc
@@ -677,6 +677,7 @@ Here are details about Asciidoctor's http://asciidoctor.org/docs/user-manual/#ad
 == Reveal.js Options
 
 There are some attributes that can be set at the top of the document which they are specific of `revealjs` converter.
+They are applied in the link:templates/document.html.slim[document template]
 
 NOTE: Default settings are based on `reveal.js` default settings.
 
@@ -877,6 +878,20 @@ a|Number of pixels to move the parallax background per slide
 |<a valid CSS display mode>
 |The display mode that will be used to show slides.
 Defaults to *block*
+
+|:revealjs_width:
+|<pixels\|percentage unit>
+| Independent from the values, the aspect ratio will be preserved
+	when scaled to fit different resolutions. Defaults to *960*
+
+|:revealjs_height:
+|<pixels\|percentage unit>
+| See `:revealjs_width:`. Defaults to *700*
+
+|:revealjs_margin:
+|<percentage value>
+| Factor of the display size that should remain empty around the content. Defaults to *0.1*
+
 |===
 
 If you want to build a custom theme or customize an existing one you should


### PR DESCRIPTION
I was positively surprised that setting `:revealjs_height:` just works.

Added three more values an a link to the template source so people
can discover more settings if needed.