### PR TITLE
feat: upgrade bundled font-awesome from 4.3.0 → 5.8.2

### DIFF
--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -25,7 +25,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
     include asciidoctor_revealjs.css.slim
     - if attr? :icons, 'font'
       - if attr? 'iconfont-remote'
-        link rel='stylesheet' href=(attr 'iconfont-cdn', %(#{cdn_base}/font-awesome/4.3.0/css/font-awesome.min.css))
+        link rel='stylesheet' href=(attr 'iconfont-cdn', %(#{cdn_base}/font-awesome/5.8.2/css/all.min.css))
       - else
         link rel='stylesheet' href=(normalize_web_path %(#{attr 'iconfont-name', 'font-awesome'}.css), (attr 'stylesdir', ''), false)
     - if attr? :stem


### PR DESCRIPTION
I was missing quite a bunch of new icons which appeared
in https://fontawesome.com/icons?d=gallery&m=free but
did not work.

This udpates font awesome to the latest CDN-available
version