### PR TITLE
Upgrade Opal to use a compatible version with Asciidoctor.js 2.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in asciidoctor-revealjs.gemspec
 gemspec
-# Asciidoctor.js 1.5.9 requires an unreleased Opal 0.11.99.dev (6703d8d)
-gem 'opal', :git => 'https://github.com/opal/opal.git', :ref => '6703d8d'
+# Asciidoctor.js 2.0.0 requires an unreleased Opal 0.11.99.dev (d136ea8)
+gem 'opal', :git => 'https://github.com/opal/opal.git', :ref => 'd136ea8'

--- a/Gemfile.upstream
+++ b/Gemfile.upstream
@@ -3,5 +3,5 @@
 source 'https://rubygems.org'
 gemspec
 gem 'asciidoctor', :git => 'https://github.com/asciidoctor/asciidoctor', :branch => 'master'
-# Asciidoctor.js 1.5.9 requires an unreleased Opal 0.11.99.dev (6703d8d)
-gem 'opal', :git => 'https://github.com/opal/opal.git', :ref => '6703d8d'
+# Asciidoctor.js 2.0.0 requires an unreleased Opal 0.11.99.dev (d136ea8)
+gem 'opal', :git => 'https://github.com/opal/opal.git', :ref => 'd136ea8'


### PR DESCRIPTION
It should also probably work with opal/opal@6703d8d but I think it's best to use the exact same version to avoid incompatible generated code.