### PR TITLE
Attempt at fixing recent Travis JRuby build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 - 2.5
 - 2.4
 - 2.3
-- jruby-head
+- jruby-9.2.9.0
 gemfile:
 - Gemfile
 - Gemfile.upstream

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 - 2.5
 - 2.4
 - 2.3
-- jruby-9k
+- jruby-head
 gemfile:
 - Gemfile
 - Gemfile.upstream


### PR DESCRIPTION
jruby-9k seems to provide a version no longer compatible with bundler.

See build failure in #292.