### PR TITLE
Issue #158: Use section title (with sectnums)

### DIFF
--- a/examples/level-sectnums.adoc
+++ b/examples/level-sectnums.adoc
@@ -1,0 +1,24 @@
+// .sections
+// Demonstration of section numbers and their specific reveal.js integration.
+// :include: //div[@class="slides"]
+// :header_footer:
+= Sectnums
+:backend: revealjs
+:sectnums:
+:sectnumlevels: 2
+
+== First level
+
+First content
+
+== Vertical
+
+Vertical slides are using level 2 sections
+
+=== Level 2
+
+==== Level 3 does not have sectnum, sectnumlevels is 2
+
+== Horizontal slide
+
+=== Also supports levels

--- a/templates/section.html.slim
+++ b/templates/section.html.slim
@@ -56,7 +56,7 @@
       data-state=(attr 'state'))
 
       - unless hide_title
-        h2=title
+        h2=section_title
       - (blocks - vertical_slides).each do |block|
         =block.convert
     - vertical_slides.each do |subsection|
@@ -87,5 +87,5 @@
       data-state=(attr 'state'))
 
       - unless hide_title
-        h2=title
+        h2=section_title
       =content.chomp

--- a/test/doctest/level-sectnums.html
+++ b/test/doctest/level-sectnums.html
@@ -1,0 +1,32 @@
+<!-- .sections -->
+<div class="slides">
+  <section class="title" data-state="title">
+    <h1>Sectnums</h1>
+  </section>
+  <section id="_first_level">
+    <h2>1. First level</h2>
+    <div class="paragraph">
+      <p>First content</p>
+    </div>
+  </section>
+  <section>
+    <section id="_vertical">
+      <h2>2. Vertical</h2>
+      <div class="paragraph">
+        <p>Vertical slides are using level 2 sections</p>
+      </div>
+    </section>
+    <section id="_level_2">
+      <h2>2.1. Level 2</h2>
+      <h3>Level 3 does not have sectnum, sectnumlevels is 2</h3>
+    </section>
+  </section>
+  <section>
+    <section id="_horizontal_slide">
+      <h2>3. Horizontal slide</h2>
+    </section>
+    <section id="_also_supports_levels">
+      <h2>3.1. Also supports levels</h2>
+    </section>
+  </section>
+</div>

--- a/test/doctest/outline.html
+++ b/test/doctest/outline.html
@@ -31,27 +31,27 @@
 
 <!-- .numbered -->
 <section id="_section_1">
-  <h2>Section 1</h2>
+  <h2>1. Section 1</h2>
 </section>
 <section id="_unnumbered_section">
   <h2>Unnumbered Section</h2>
 </section>
 <section>
   <section id="_section_2">
-    <h2>Section 2</h2>
+    <h2>2. Section 2</h2>
   </section>
   <section id="_section_2_1">
-    <h2>Section 2.1</h2>
+    <h2>2.1. Section 2.1</h2>
   </section>
 </section>
 <section id="_section_3">
-  <h2>Section 3</h2>
+  <h2>3. Section 3</h2>
 </section>
 
 <!-- .sectnumlevels -->
 <section>
   <section id="_section_1">
-    <h2>Section 1</h2>
+    <h2>1. Section 1</h2>
   </section>
   <section id="_section_1_1">
     <h2>Section 1.1</h2>
@@ -59,5 +59,5 @@
   </section>
 </section>
 <section id="_section_2">
-  <h2>Section 2</h2>
+  <h2>2. Section 2</h2>
 </section>

--- a/test/doctest/section.html
+++ b/test/doctest/section.html
@@ -60,32 +60,32 @@
 
 <!-- .numbered -->
 <section id="_introduction_to_asciidoctor">
-  <h2>Introduction to Asciidoctor</h2>
+  <h2>1. Introduction to Asciidoctor</h2>
 </section>
 <section>
   <section id="_quick_starts">
-    <h2>Quick Starts</h2>
+    <h2>2. Quick Starts</h2>
   </section>
   <section id="_usage">
-    <h2>Usage</h2>
+    <h2>2.1. Usage</h2>
     <h3>Using the Command Line Interface</h3>
     <h4>Processing Your Content</h4>
   </section>
   <section id="_syntax">
-    <h2>Syntax</h2>
+    <h2>2.2. Syntax</h2>
   </section>
 </section>
 <section id="_terms_and_concepts">
-  <h2>Terms and Concepts</h2>
+  <h2>3. Terms and Concepts</h2>
 </section>
 
 <!-- .numbered-sectnumlevels-1 -->
 <section id="_introduction_to_asciidoctor">
-  <h2>Introduction to Asciidoctor</h2>
+  <h2>1. Introduction to Asciidoctor</h2>
 </section>
 <section>
   <section id="_quick_starts">
-    <h2>Quick Starts</h2>
+    <h2>2. Quick Starts</h2>
   </section>
   <section id="_usage">
     <h2>Usage</h2>
@@ -96,7 +96,7 @@
   </section>
 </section>
 <section id="_terms_and_concepts">
-  <h2>Terms and Concepts</h2>
+  <h2>3. Terms and Concepts</h2>
 </section>
 
 <!-- .book-part-title -->


### PR DESCRIPTION
I found that in helpers.rb the section_title was already defined with sectnum support.
I'm not sure if it is as simple as that, but I changed the section template to use this helper.