### PR TITLE
resolves #198 resolves docinfo head, header and footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # test stuff
 /examples/*.html
+!/examples/docinfo*.html
 /examples/reveal.js/
 /examples/node_modules
 

--- a/README.adoc
+++ b/README.adoc
@@ -765,6 +765,41 @@ WARNING: This presentation is dangerous!
 
 Here are details about Asciidoctor's http://asciidoctor.org/docs/user-manual/#admonition-icons[Admonition icons] support.
 
+=== Supplemental Content with Docinfo
+// Originally from https://github.com/asciidoctor/asciidoctor-bespoke#supplemental-content
+
+It's possible to inject supplemental content into the output document using http://asciidoctor.org/docs/user-manual/#docinfo-file[docinfo files].
+This core feature of AsciiDoc has been adapted to work with the reveal.js converter.
+
+Currently, there are three insertion locations for docinfo content in a reveal.js document:
+
+head:: content is inserted after the last child of the `<head>` element
+header:: content is inserted before the first child of the `<div class="slides">` element (before the slides)
+footer:: content is inserted after the last child of the `<div class="slides">` element (after the slides)
+
+The content you want to insert goes into a sibling file of the slide deck document with the following filename patterns:
+
+head:: `docinfo-revealjs.html`
+header:: `docinfo-header-revealjs.html`
+footer:: `docinfo-footer-revealjs.html`
+
+For example, let's say you want to embed a tweet into your slide deck.
+You might inject the shared embedding JavaScript using a footer docinfo file:
+
+.src/docinfo-footer-revealjs.html
+[source,html]
+----
+<script src="https://platform.twitter.com/widgets.js"></script>
+----
+
+You then need to set the following document attribute in the AsciiDoc header:
+
+----
+:docinfo: shared
+----
+
+When this attribute is defined, the converter will automatically read the docinfo file(s) and insert the contents into the specified location in the output document.
+
 
 == Reveal.js Options
 

--- a/examples/docinfo-footer-revealjs.html
+++ b/examples/docinfo-footer-revealjs.html
@@ -1,0 +1,10 @@
+<script src="https://platform.twitter.com/widgets.js"></script>
+<script>
+  twttr.widgets.createTweet(
+    '1214773648776744962',
+    document.getElementById('tweet'),
+    {
+      theme: 'white'
+    }
+  );
+</script>

--- a/examples/docinfo-revealjs.html
+++ b/examples/docinfo-revealjs.html
@@ -1,0 +1,7 @@
+<meta name="generator" content="Asciidoctor reveal.js">
+<style>
+  #tweet {
+    display: flex;
+    justify-content: center;
+  }
+</style>

--- a/examples/with-docinfo-shared.adoc
+++ b/examples/with-docinfo-shared.adoc
@@ -1,0 +1,9 @@
+= Docinfo shared
+:docinfo: shared
+
+== Tweet
+
+// placeholder
+[#tweet]
+--
+--

--- a/examples/with-docinfo-shared.adoc
+++ b/examples/with-docinfo-shared.adoc
@@ -1,3 +1,7 @@
+// .docinfo-shared
+// Demonstration of docinfo attribute and we provide only head and footer values
+// :include: //head/*[last()] | //div[@class="slides"]/*[last()]
+// :header_footer:
 = Docinfo shared
 :docinfo: shared
 

--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -62,44 +62,22 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
       document.getElementsByTagName( 'head' )[0].appendChild( link );
     /[if lt IE 9]
       <script src="#{revealjsdir}/lib/js/html5shiv.js"></script>
-    - unless (docinfo_content = docinfo :header, '.html').empty?
-      =docinfo_content
     - if attr? :customcss
       link rel='stylesheet' href=((customcss = attr :customcss).empty? ? 'asciidoctor-revealjs.css' : customcss)
+    - unless (_docinfo = docinfo :head, '-revealjs.html').empty?
+      =_docinfo
   body
     .reveal
       / Any section element inside of this container is displayed as a slide
       .slides
-        - unless notitle || !has_header?
-          - bg_image = (attr? 'title-slide-background-image') ? (image_uri(attr 'title-slide-background-image')) : nil
-          - bg_video = (attr? 'title-slide-background-video') ? (media_uri(attr 'title-slide-background-video')) : nil
-          section.title(class = role
-            data-state='title'
-            data-transition=(attr 'title-slide-transition')
-            data-transition-speed=(attr 'title-slide-transition-speed')
-            data-background=(attr 'title-slide-background')
-            data-background-size=(attr 'title-slide-background-size')
-            data-background-image=bg_image
-            data-background-video=bg_video
-            data-background-video-loop=(attr 'title-slide-background-video-loop')
-            data-background-video-muted=(attr 'title-slide-background-video-muted')
-            data-background-opacity=(attr "background-opacity")
-            data-background-iframe=(attr 'title-slide-background-iframe')
-            data-background-color=(attr 'title-slide-background-color')
-            data-background-repeat=(attr 'title-slide-background-repeat')
-            data-background-position=(attr 'title-slide-background-position')
-            data-background-transition=(attr 'title-slide-background-transition'))
-            - if (_title_obj = doctitle partition: true, use_fallback: true).subtitle?
-              h1=slice_text _title_obj.title, (_slice = header.option? :slice)
-              h2=slice_text _title_obj.subtitle, _slice
-            - else
-              h1=@header.title
-            - preamble = @document.find_by context: :preamble
-            - unless preamble.nil? or preamble.length == 0
-              div.preamble=preamble.pop.content
-            - unless author.nil?
-              p.author: small=author
-        =content
+        - unless noheader
+          - unless (_docinfo = docinfo :header, '-revealjs.html').empty?
+            = _docinfo
+          - if header?
+            include slide_title.html.slim
+        = content
+        - unless (_docinfo = docinfo :footer, '-revealjs.html').empty?
+          = _docinfo
     script src="#{revealjsdir}/lib/js/head.min.js"
     script src="#{revealjsdir}/js/reveal.js"
     javascript:

--- a/templates/slide_title.html.slim
+++ b/templates/slide_title.html.slim
@@ -1,0 +1,28 @@
+- bg_image = (attr? 'title-slide-background-image') ? (image_uri(attr 'title-slide-background-image')) : nil
+- bg_video = (attr? 'title-slide-background-video') ? (media_uri(attr 'title-slide-background-video')) : nil
+section.title(class = role
+  data-state='title'
+  data-transition=(attr 'title-slide-transition')
+  data-transition-speed=(attr 'title-slide-transition-speed')
+  data-background=(attr 'title-slide-background')
+  data-background-size=(attr 'title-slide-background-size')
+  data-background-image=bg_image
+  data-background-video=bg_video
+  data-background-video-loop=(attr 'title-slide-background-video-loop')
+  data-background-video-muted=(attr 'title-slide-background-video-muted')
+  data-background-opacity=(attr "background-opacity")
+  data-background-iframe=(attr 'title-slide-background-iframe')
+  data-background-color=(attr 'title-slide-background-color')
+  data-background-repeat=(attr 'title-slide-background-repeat')
+  data-background-position=(attr 'title-slide-background-position')
+  data-background-transition=(attr 'title-slide-background-transition'))
+  - if (_title_obj = doctitle partition: true, use_fallback: true).subtitle?
+    h1=slice_text _title_obj.title, (_slice = header.option? :slice)
+    h2=slice_text _title_obj.subtitle, _slice
+  - else
+    h1=@header.title
+  - preamble = @document.find_by context: :preamble
+  - unless preamble.nil? or preamble.length == 0
+    div.preamble=preamble.pop.content
+  - unless author.nil?
+    p.author: small=author


### PR DESCRIPTION
Inspired by https://github.com/asciidoctor/asciidoctor-bespoke/blob/master/templates/slim/document.html.slim


I've added an example to make sure that it's working and here the result:

![tweet](https://user-images.githubusercontent.com/333276/73469381-91433180-4386-11ea-9b3e-5e7eb3feffc8.png)

As suggested by @mojavelinux I've added a unique suffix but it's a breaking change because `docinfo.html` won't be resolved (it must be renamed to `docinfo-revealjs.html`)

resolves #198