### PR TITLE
Remove empty lines in the reveal.js dependencies configuration

### DIFF
--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -239,12 +239,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
 
         // Optional libraries used to extend on reveal.js
         dependencies: [
-            #{(document.attr? 'source-highlighter', 'highlightjs') ? "{ src: '#{revealjsdir}/plugin/highlight/highlight.js', async: true }," : nil}
-            #{(attr? 'revealjs_plugin_zoom', 'disabled') ? "" :  "{ src: '#{revealjsdir}/plugin/zoom-js/zoom.js', async: true }," }
-            #{(attr? 'revealjs_plugin_notes', 'disabled') ? "" :  "{ src: '#{revealjsdir}/plugin/notes/notes.js', async: true }," }
-            #{(attr? 'revealjs_plugin_marked', 'enabled') ? "{ src: '#{revealjsdir}/plugin/markdown/marked.js' }," : "" }
-            #{(attr? 'revealjs_plugin_markdown', 'enabled') ? "{ src: '#{revealjsdir}/plugin/markdown/markdown.js' }," : "" }
-            #{(attr? 'revealjs_plugins') ? File.read(attr('revealjs_plugins', '')) : ""}
+            #{revealjs_dependencies(document, self, revealjsdir)}
         ],
 
         #{(attr? 'revealjs_plugins_configuration') ? File.read(attr('revealjs_plugins_configuration', '')) : ""}

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -118,6 +118,21 @@ module Slim::Helpers
     end
   end
 
+  def revealjs_dependencies(document, node, revealjsdir)
+    dependencies = []
+    dependencies << "{ src: '#{revealjsdir}/plugin/highlight/highlight.js', async: true }" if (document.attr? 'source-highlighter', 'highlightjs')
+    dependencies << "{ src: '#{revealjsdir}/plugin/zoom-js/zoom.js', async: true }" unless (node.attr? 'revealjs_plugin_zoom', 'disabled')
+    dependencies << "{ src: '#{revealjsdir}/plugin/notes/notes.js', async: true }" unless (node.attr? 'revealjs_plugin_notes', 'disabled')
+    dependencies << "{ src: '#{revealjsdir}/plugin/markdown/marked.js', async: true }" if (node.attr? 'revealjs_plugin_marked', 'enabled')
+    dependencies << "{ src: '#{revealjsdir}/plugin/markdown/markdown.js', async: true }" if (node.attr? 'revealjs_plugin_markdown', 'enabled')
+    if (node.attr? 'revealjs_plugins') &&
+        !(revealjs_plugins_file = (node.attr 'revealjs_plugins', '').strip).empty? &&
+        !(revealjs_plugins_content = (File.read revealjs_plugins_file).strip).empty?
+      dependencies << revealjs_plugins_content
+    end
+    dependencies.join(",\n      ")
+  end
+
 
   # Between delimiters (--) is code taken from asciidoctor-bespoke 1.0.0.alpha.1
   # Licensed under MIT, Copyright (C) 2015-2016 Dan Allen and the Asciidoctor Project

--- a/test/doctest/fragments.html
+++ b/test/doctest/fragments.html
@@ -218,12 +218,8 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
-        { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
-
+        { src: 'reveal.js/plugin/notes/notes.js', async: true }
     ],
 
 

--- a/test/doctest/history-hash.html
+++ b/test/doctest/history-hash.html
@@ -179,12 +179,8 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
-        { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
-
+        { src: 'reveal.js/plugin/notes/notes.js', async: true }
     ],
 
 

--- a/test/doctest/history-regression-tests.html
+++ b/test/doctest/history-regression-tests.html
@@ -201,12 +201,8 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
-        { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
-
+        { src: 'reveal.js/plugin/notes/notes.js', async: true }
     ],
 
 

--- a/test/doctest/history.html
+++ b/test/doctest/history.html
@@ -179,12 +179,8 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
-        { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
-
+        { src: 'reveal.js/plugin/notes/notes.js', async: true }
     ],
 
 

--- a/test/doctest/links-preview.html
+++ b/test/doctest/links-preview.html
@@ -193,12 +193,8 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
-        { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
-
+        { src: 'reveal.js/plugin/notes/notes.js', async: true }
     ],
 
 

--- a/test/doctest/revealjs-plugin-activation.html
+++ b/test/doctest/revealjs-plugin-activation.html
@@ -174,12 +174,8 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
-        { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
-
+        { src: 'reveal.js/plugin/notes/notes.js', async: true }
     ],
 
 

--- a/test/doctest/revealjs-plugins.html
+++ b/test/doctest/revealjs-plugins.html
@@ -174,14 +174,10 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
         { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
         { src: 'revealjs-plugins/reveal.js-menu/menu.js' },
-  { src: 'revealjs-plugins/chalkboard/chalkboard.js' }
-
+{ src: 'revealjs-plugins/chalkboard/chalkboard.js' }
     ],
 
     menu: {

--- a/test/doctest/theme-custom.html
+++ b/test/doctest/theme-custom.html
@@ -187,12 +187,8 @@
 
     // Optional libraries used to extend on reveal.js
     dependencies: [
-
         { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
-        { src: 'reveal.js/plugin/notes/notes.js', async: true },
-
-
-
+        { src: 'reveal.js/plugin/notes/notes.js', async: true }
     ],
 
 


### PR DESCRIPTION
Build an array and join the plugins in the `helpers.rb` file.
Another benefit is that we can now write unit tests to validate the logic.