### PR TITLE
Cancel Asciidoctor line-height in highlight.js table (fixes #331)

### DIFF
--- a/examples/source-emphasis.adoc
+++ b/examples/source-emphasis.adoc
@@ -5,6 +5,11 @@
 = Source Code Emphasis
 :icons: font
 :source-highlighter: highlightjs
+:highlightjs-languages: x86asm
+:customcss: source-emphasis.css
+:revealjs_hash: yes
+:revealjs_height: 1080
+:revealjs_width: 1920
 
 == Using Asciidoctor features
 
@@ -84,3 +89,30 @@ function Example() {
   );
 }
 ----
+
+== ASM from Compiler
+
+[source.col2,x86asm,highlight="3..6|7..9|10|11,12"]
+----
+main        proc near
+var_10      = dword ptr -10h
+            push ebp                      <1>
+            mov ebp, esp
+            and esp, 0FFFFFFF0h
+            sub esp, 10h
+            mov eax, offset aHelloWorld   <2>
+            mov [esp+10h+var_10], eax
+            call _printf
+            mov eax, 0                    <3>
+            leave                         <4>
+            retn
+main        endp
+----
+
+[.col2]
+--
+<1> Function prologue
+<2> Preparing arguments and calling `printf`
+<3> Clean-up registers
+<4> Function epilogue
+--

--- a/examples/source-emphasis.css
+++ b/examples/source-emphasis.css
@@ -1,0 +1,9 @@
+/* WARNING: this will likely be replaced by something else soon */
+.col2 {
+  width:48% !important;
+  margin: 0 1% !important;
+  float:left;
+}
+.reveal .col2 ol, .reveal .col2  dl, .reveal .col2  ul {
+    display:table;
+}

--- a/templates/asciidoctor-compatibility.css
+++ b/templates/asciidoctor-compatibility.css
@@ -53,3 +53,4 @@ b.conum *{color:inherit!important}
 
 /* Override Asciidoctor CSS that causes issues with reveal.js features */
 .reveal .hljs table{border: 0}
+.reveal .hljs table thead tr th, .reveal .hljs table tfoot tr th, .reveal .hljs table tbody tr td, .reveal .hljs table tr td, .reveal .hljs table tfoot tr td{line-height:inherit}

--- a/test/doctest/source-emphasis.html
+++ b/test/doctest/source-emphasis.html
@@ -83,4 +83,57 @@ function Example() {
       </div>
     </div>
   </section>
+  <section id="_asm_from_compiler">
+    <h2>ASM from Compiler</h2>
+    <div class="listingblock col2">
+      <div class="content">
+        <pre class="highlightjs highlight"><code class="language-x86asm hljs" data-lang="x86asm" data-line-numbers="3,4,5,6|7,8,9|10|11,12" data-noescape="true">main        proc near
+var_10      = dword ptr -10h
+            push ebp                      <i class="conum" data-value="1"></i><b>(1)</b>
+            mov ebp, esp
+            and esp, 0FFFFFFF0h
+            sub esp, 10h
+            mov eax, offset aHelloWorld   <i class="conum" data-value="2"></i><b>(2)</b>
+            mov [esp+10h+var_10], eax
+            call _printf
+            mov eax, 0                    <i class="conum" data-value="3"></i><b>(3)</b>
+            leave                         <i class="conum" data-value="4"></i><b>(4)</b>
+            retn
+main        endp</code></pre>
+      </div>
+    </div>
+    <div class="openblock col2">
+      <div class="content">
+        <div class="colist arabic">
+          <table>
+            <tr>
+              <td>
+                <i class="conum" data-value="1"></i><b>1</b>
+              </td>
+              <td>Function prologue</td>
+            </tr>
+            <tr>
+              <td>
+                <i class="conum" data-value="2"></i><b>2</b>
+              </td>
+              <td>Preparing arguments and calling <code>printf</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <i class="conum" data-value="3"></i><b>3</b>
+              </td>
+              <td>Clean-up registers</td>
+            </tr>
+            <tr>
+              <td>
+                <i class="conum" data-value="4"></i><b>4</b>
+              </td>
+              <td>Function epilogue</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
 </div>


### PR DESCRIPTION
![arjs-hls-fix](https://user-images.githubusercontent.com/546325/74210384-8b3c3300-4c59-11ea-97c7-781e3c59df40.png)
