### PR TITLE
Cosmetic improvements to callout lists

### DIFF
--- a/examples/source-emphasis.adoc
+++ b/examples/source-emphasis.adoc
@@ -8,7 +8,7 @@
 
 == Using Asciidoctor features
 
-Using bold markers and `subs="+quotes,+macros"` attribute
+=== Bold markers and `subs="+quotes,+macros"` attribute
 
 [source,java,subs="+quotes,+macros"]
 ----
@@ -22,6 +22,17 @@ protected void configure(HttpSecurity http) throws Exception {
             .loginPage("/login")
             .permitAll();
 ----
+
+=== Callouts
+
+[source, rust]
+----
+fn main() {
+    println!("Hello World!"); // <1>
+}
+----
+<1> `println!` is a macro.
+
 
 == Using reveal.js <mark> tags
 

--- a/templates/asciidoctor-compatibility.css
+++ b/templates/asciidoctor-compatibility.css
@@ -55,7 +55,7 @@ b.conum *{color:inherit!important}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+/* .literalblock+.colist,.listingblock+.colist{margin-top:-.5em} */
 .colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
 .colist td:not([class]):first-child img{max-width:none}
 .colist td:not([class]):last-child{padding:.25em 0}

--- a/templates/asciidoctor-compatibility.css
+++ b/templates/asciidoctor-compatibility.css
@@ -50,6 +50,16 @@ kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-bl
 pre .conum[data-value]{position:relative;top:-.125em}
 b.conum *{color:inherit!important}
 .conum:not([data-value]):empty{display:none}
+/* callout lists */
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
 
 /* Override Asciidoctor CSS that causes issues with reveal.js features */
 .reveal .hljs table{border: 0}
+.reveal .colist>table th, .reveal .colist>table td {border-bottom:0}

--- a/test/doctest/source-emphasis.html
+++ b/test/doctest/source-emphasis.html
@@ -3,14 +3,15 @@
   <section class="title" data-state="title">
     <h1>Source Code Emphasis</h1>
   </section>
-  <section id="_using_asciidoctor_features">
-    <h2>Using Asciidoctor features</h2>
-    <div class="paragraph">
-      <p>Using bold markers and <code>subs="+quotes,+macros"</code> attribute</p>
-    </div>
-    <div class="listingblock">
-      <div class="content">
-        <pre class="highlightjs highlight"><code class="language-java hljs" data-lang="java" data-noescape="true">protected void configure(HttpSecurity http) throws Exception {
+  <section>
+    <section id="_using_asciidoctor_features">
+      <h2>Using Asciidoctor features</h2>
+    </section>
+    <section id="_bold_markers_and_subsquotesmacros_attribute">
+      <h2>Bold markers and <code>subs="+quotes,+macros"</code> attribute</h2>
+      <div class="listingblock">
+        <div class="content">
+          <pre class="highlightjs highlight"><code class="language-java hljs" data-lang="java" data-noescape="true">protected void configure(HttpSecurity http) throws Exception {
     http
         .authorizeRequests()
             <strong>.antMatchers("/resources/**").permitAll()</strong>
@@ -19,8 +20,30 @@
         .formLogin()
             .loginPage("/login")
             .permitAll();</code></pre>
+        </div>
       </div>
-    </div>
+    </section>
+    <section id="_callouts">
+      <h2>Callouts</h2>
+      <div class="listingblock">
+        <div class="content">
+          <pre class="highlightjs highlight"><code class="language-rust hljs" data-lang="rust" data-noescape="true">fn main() {
+    println!("Hello World!"); <i class="conum" data-value="1"></i><b>(1)</b>
+}</code></pre>
+        </div>
+      </div>
+      <div class="colist arabic">
+        <table>
+          <tr>
+            <td>
+              <i class="conum" data-value="1"></i><b>1</b>
+            </td>
+            <td>
+              <code>println!</code> is a macro.</td>
+          </tr>
+        </table>
+      </div>
+    </section>
   </section>
   <section id="_using_reveal_js_mark_tags">
     <h2>Using reveal.js &lt;mark&gt; tags</h2>


### PR DESCRIPTION
Merge after #334 

* Imported styles from Asciidoctor
* Required an override for bottom border
* Disabled upstream style with a negative margin causing overlap if `.stretched` class is used
