### PR TITLE
Fix for issue #348

### DIFF
--- a/examples/mathjax.adoc
+++ b/examples/mathjax.adoc
@@ -1,0 +1,20 @@
+// .links
+// Demonstration of reveal.js and Mathjax integration
+// :include: //div[@class="slides"]
+// :header_footer:
+= MathJax
+:stem:
+:revealjsdir: https://cdn.jsdelivr.net/npm/reveal.js@3.9.2
+
+== Math Equation
+
+Using standard latexmath:[\LaTeX] syntax:
+
+[stem]
+++++
+\sqrt{37} = \sqrt{\frac{73^2-1}{12^2}} \approx \frac{73}{12} (1 - \frac{1}{2\cdot73^2})
+++++
+
+Another one:
+
+stem:[\sum_{i=0}^n i^2 = \frac{(n^2+n)(2n+1)}{6}]

--- a/examples/mathjax.adoc
+++ b/examples/mathjax.adoc
@@ -1,5 +1,5 @@
-// .links
-// Demonstration of reveal.js and Mathjax integration
+// .mathjax
+// Demonstration of our Mathjax integration
 // :include: //div[@class="slides"]
 // :header_footer:
 = MathJax

--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -39,6 +39,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
       - eqnums_val = (attr 'eqnums', 'none')
       - eqnums_val = 'AMS' if eqnums_val == ''
       - eqnums_opt = %( equationNumbers: { autoNumber: "#{eqnums_val}" } )
+      - mathjaxdir = (attr 'mathjaxdir', "#{cdn_base}/mathjax/2.4.0")
       script type='text/x-mathjax-config'
         | MathJax.Hub.Config({
           tex2jax: {
@@ -52,7 +53,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
           },
           TeX: {#{eqnums_opt}}
           });
-      script src='#{cdn_base}/mathjax/2.4.0/MathJax.js?config=TeX-MML-AM_HTMLorMML'
+      script src='#{mathjaxdir}/MathJax.js?config=TeX-MML-AM_HTMLorMML'
 
     - syntax_hl = self.syntax_highlighter
     - if syntax_hl && (syntax_hl.docinfo? :head)


### PR DESCRIPTION
This PR provides a fix for #348, using a new attribute `mathjaxdir` set in the Asciidoc source.

Thanks to this, the user could for example `npm install mathjax@2.7.7` and then set the `mathjaxdir` attribute: `:mathjaxdir: node_modules/mathjax` to load the library locally instead of from the CDN.

If the attribute is not set, the behaviour is exactly the same as it is currently.