### PR TITLE
example of a margin config upstream issue when printing

### DIFF
--- a/examples/issue-revealjs-stretch-margin-print.adoc
+++ b/examples/issue-revealjs-stretch-margin-print.adoc
@@ -1,0 +1,20 @@
+// .issue-revealjs-stretch-margin-print
+// This example shows the impact of using the reveal.js special stretch CSS class
+// :include: //div[@class="slides"]
+// :header_footer:
+= Stretch and Margin Printing Bug
+:imagesdir: images
+:revealjs_width: 1080
+:revealjs_margin: 0.01
+
+== How-To
+
+1. Load this deck with `?print-pdf` at the end of the address bar to trigger PDF
+export mode.
+1. Try printing the deck
+1. Notice that the stretched image doesn't appear
+
+== Demonstration of Issue
+
+[.stretch]
+image::70s.jpg[]


### PR DESCRIPTION
This example is just to highlight an issue that is complicated to track down. It might be considered an upstream issue but since it is caused by using an aggressively thin margin I'm not sure how it would be received upstream...

I've stopped using such an aggressively thin margin downstream but I want this to be "documented" so others can avoid the same mistake.

Draft for now so I don't forget.