### PR TITLE
background-video doesn't honor imagesdir attribute like it should

### DIFF
--- a/examples/video.adoc
+++ b/examples/video.adoc
@@ -34,7 +34,6 @@ video::https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-e
 [background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm",options="loop,muted,notitle"]
 == background video at URL with options
 
-// FIXME doesn't load
 // Download this file and put in examples/images/ for this to be visible
 // https://github.com/obilodeau/asciidoctor-assets/blob/master/videos/synthwave.mp4
 [%notitle,background-video="synthwave.mp4",background-video-loop=true,background-video-muted=true]

--- a/examples/video.adoc
+++ b/examples/video.adoc
@@ -4,6 +4,7 @@
 // :header_footer:
 = Video tests
 :revealjs_hash: true
+:imagesdir: images/
 
 == YouTube Auto-sized
 
@@ -25,13 +26,26 @@ This video is auto-sized!
 video::https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm[]
 
 [%notitle,background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&start=3&enablejsapi=1&autoplay=1&loop=1&controls=0&modestbranding=1"]
-== background
+== background video at URL
 
 [%notitle,background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm",background-video-loop=true,background-video-muted=true]
-== video file, named attributes
+== background video at URL with named attributes
 
 [background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm",options="loop,muted,notitle"]
+== background video at URL with options
+
+// FIXME doesn't load
+// Download this file and put in examples/images/ for this to be visible
+// https://github.com/obilodeau/asciidoctor-assets/blob/master/videos/synthwave.mp4
+[%notitle,background-video="synthwave.mp4",background-video-loop=true,background-video-muted=true]
+== background video file with named attributes
+
+// Download this file and put in examples/images/ for this to be visible
+// https://github.com/obilodeau/asciidoctor-assets/blob/master/videos/synthwave.mp4
 == video file, options
+
+video::synthwave.mp4[options="autoplay,loop"]
+
 
 == vimeo autostart
 

--- a/templates/section.html.slim
+++ b/templates/section.html.slim
@@ -30,6 +30,9 @@
 - if attr? 'background-image'
   - data_background_image = image_uri(attr 'background-image')
 
+- if attr? 'background-video'
+  - data_background_video = media_uri(attr 'background-video')
+
 - if attr? 'background-color'
   - data_background_color = attr 'background-color'
 
@@ -47,7 +50,7 @@
     data-background-transition=(data_background_transition || attr('background-transition'))
     data-background-position=(data_background_position || attr('background-position'))
     data-background-iframe=(attr "background-iframe")
-    data-background-video=(attr "background-video")
+    data-background-video=data_background_video
     data-background-video-loop=((attr? 'background-video-loop') || (option? 'loop'))
     data-background-video-muted=((attr? 'background-video-muted') || (option? 'muted'))
     data-background-opacity=(attr "background-opacity")

--- a/test/doctest/video.html
+++ b/test/doctest/video.html
@@ -68,9 +68,18 @@
       </div>
     </div>
   </section>
-  <section data-background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&amp;start=3&amp;enablejsapi=1&amp;autoplay=1&amp;loop=1&amp;controls=0&amp;modestbranding=1" id="_background"></section>
-  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_video_file_named_attributes"></section>
-  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_video_file_options"></section>
+  <section data-background-iframe="https://www.youtube.com/embed/LaApqL4QjH8?rel=0&amp;start=3&amp;enablejsapi=1&amp;autoplay=1&amp;loop=1&amp;controls=0&amp;modestbranding=1" id="_background_video_at_url"></section>
+  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_background_video_at_url_with_named_attributes"></section>
+  <section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4,https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.webm" data-background-video-loop="" data-background-video-muted="" id="_background_video_at_url_with_options"></section>
+  <section data-background-video="images/synthwave.mp4" data-background-video-loop="" data-background-video-muted="" id="_background_video_file_with_named_attributes"></section>
+  <section id="_video_file_options">
+    <h2>video file, options</h2>
+    <div class="slide-content">
+      <div class="videoblock stretch">
+        <video controls="" data-autoplay="" height="100%" loop="" src="images/synthwave.mp4" width="100%">Your browser does not support the video tag.</video>
+      </div>
+    </div>
+  </section>
   <section id="_vimeo_autostart">
     <h2>vimeo autostart</h2>
     <div class="slide-content">


### PR DESCRIPTION
Investigating what I thought was a problem with Asciidoctor, I realize that we are badly loading background-video local files.

Asciidoctor uses the [`media_uri` method](https://github.com/asciidoctor/asciidoctor/blob/bb47c333df0aaab6daefa1f4acd3ba3d2623c0c8/lib/asciidoctor/abstract_node.rb#L325) to lookup video files and we used it in the video template but for `background-video` this wasn't used.

This PR fixes that behavior.

Now, is this a backward-incompatible fix? It could break existing decks that relied on the wrong behavior. However, it was obviously broken and didn't follow what an Asciidoctor/AsciiDoc user would expect. I'm open to make this change part of a feature release but I would find it intense to bump a major version because of this. Guidance needed here.

Note
* Title slide `background-video` is already correctly implemented
* ~The first commit just exhibit the bug (I want to see it in travis), I have a local fix read to be pushed~ fix pushed