### PR TITLE
Fixed embedded autoplay videos on Youtube and Vimeo

### DIFF
--- a/examples/video.adoc
+++ b/examples/video.adoc
@@ -4,11 +4,15 @@
 // :header_footer:
 = Video tests
 :revealjs_hash: true
+:imagesdir: images/
 
 == YouTube Auto-sized
 
+video::kZH9JtPBq7k[youtube, start=34]
+
+== YouTube Auto-sized Auto-starts
+
 video::kZH9JtPBq7k[youtube, start=34, options=autoplay]
-//video::kZH9JtPBq7k[youtube, start=34, height=600, width=800, options=autoplay]
 
 [%notitle]
 == YouTube Auto-sized notitle
@@ -36,6 +40,3 @@ video::https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-e
 == vimeo autostart
 
 video::44878206[vimeo, options=autoplay]
-
-// data-autoplay is not supported on vimeo videos
-// upstream: https://github.com/hakimel/reveal.js/issues/388

--- a/templates/video.html.slim
+++ b/templates/video.html.slim
@@ -15,11 +15,12 @@
     - delimiter = '?'
     - loop_param = (option? 'loop') ? "#{delimiter}loop=1" : nil
     - src = %(#{asset_uri_scheme}//player.vimeo.com/video/#{attr :target}#{start_anchor}#{loop_param})
+    / We need to delegate autoplay into the iframe starting with Chrome 62 (and other browsers too)
+    / See https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#iframe
     iframe(width=(width) height=(height) src=src frameborder=0
       webkitAllowFullScreen=true mozallowfullscreen=true allowFullScreen=true
-      data-autoplay=(option? 'autoplay'))
-    / data-autoplay is not supported on vimeo videos
-    / upstream: https://github.com/hakimel/reveal.js/issues/388
+      data-autoplay=(option? 'autoplay')
+      allow=((option? 'autoplay') ? "autoplay" : nil))
   - when 'youtube'
     - unless (asset_uri_scheme = (attr :asset_uri_scheme, 'https')).empty?
       -  asset_uri_scheme = %(#{asset_uri_scheme}:)
@@ -28,10 +29,14 @@
     - params << "end=#{attr :end}" if attr? :end
     - params << "loop=1" if option? 'loop'
     - params << "controls=0" if option? 'nocontrols'
+    /- params << "autoplay=1" if option? 'autoplay'
     - src = %(#{asset_uri_scheme}//www.youtube.com/embed/#{attr :target}?#{params * '&amp;'})
+    / We need to delegate autoplay into the iframe starting with Chrome 62 (and other browsers too)
+    / See https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#iframe
     iframe(width=(width) height=(height) src=src
       frameborder=0 allowfullscreen=!(option? 'nofullscreen')
-      data-autoplay=(option? 'autoplay'))
+      data-autoplay=(option? 'autoplay')
+      allow=((option? 'autoplay') ? "autoplay" : nil))
   - else
     video(src=media_uri(attr :target) width=(width) height=(height)
       poster=((attr :poster) ? media_uri(attr :poster) : nil)

--- a/templates/video.html.slim
+++ b/templates/video.html.slim
@@ -29,7 +29,6 @@
     - params << "end=#{attr :end}" if attr? :end
     - params << "loop=1" if option? 'loop'
     - params << "controls=0" if option? 'nocontrols'
-    /- params << "autoplay=1" if option? 'autoplay'
     - src = %(#{asset_uri_scheme}//www.youtube.com/embed/#{attr :target}?#{params * '&amp;'})
     / We need to delegate autoplay into the iframe starting with Chrome 62 (and other browsers too)
     / See https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#iframe

--- a/test/doctest/video.html
+++ b/test/doctest/video.html
@@ -47,12 +47,18 @@
   <section id="_youtube_auto_sized">
     <h2>YouTube Auto-sized</h2>
     <div class="slide-content">
-      <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
+      <div class="videoblock stretch"><iframe allowfullscreen="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
+    </div>
+  </section>
+  <section id="_youtube_auto_sized_auto_starts">
+    <h2>YouTube Auto-sized Auto-starts</h2>
+    <div class="slide-content">
+      <div class="videoblock stretch"><iframe allow="autoplay" allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
     </div>
   </section>
   <section id="_youtube_auto_sized_notitle">
     <div class="slide-content">
-      <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
+      <div class="videoblock stretch"><iframe allow="autoplay" allowfullscreen="" data-autoplay="" frameborder="0" height="100%" src="https://www.youtube.com/embed/kZH9JtPBq7k?rel=0&amp;start=34" width="100%"></iframe></div>
       <aside class="notes">
         <div class="paragraph">
           <p>This video is auto-sized!</p>
@@ -74,7 +80,7 @@
   <section id="_vimeo_autostart">
     <h2>vimeo autostart</h2>
     <div class="slide-content">
-      <div class="videoblock stretch"><iframe allowfullscreen="" data-autoplay="" frameborder="0" height="100%" mozallowfullscreen="" src="https://player.vimeo.com/video/44878206" webkitallowfullscreen="" width="100%"></iframe></div>
+      <div class="videoblock stretch"><iframe allow="autoplay" allowfullscreen="" data-autoplay="" frameborder="0" height="100%" mozallowfullscreen="" src="https://player.vimeo.com/video/44878206" webkitallowfullscreen="" width="100%"></iframe></div>
     </div>
   </section>
 </div>


### PR DESCRIPTION
iframes requires `allow="autoplay"` HTML attribute to allow content to autoplay now.

It might be a little more complicated since Chrome uses many heuristics to determine if a given domain can or can't autoplay iframes. See  https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#iframe

My experience: using `file:///` URIs to load slidedecks I was never able to get block or inline videos hosted on youtube or vimeo to work reliably in the last few months. This was on both Chromium and Firefox. 

Also, in the meantime, we released 4.0 and `background-video` with autoplay works perfectly (see #316).

So coming back to this problem I diff'ed the iframes from both approaches (one done by reveal.js and the other by us) I found about that `allow="autoplay"` attribute. Adding it to the iframe in the video template fixes the problem.