### PR TITLE
Added example loading Mathjax from CDN

### DIFF
--- a/examples/mathjax-cdn.adoc
+++ b/examples/mathjax-cdn.adoc
@@ -1,0 +1,21 @@
+// .mathjax
+// Demonstration of our Mathjax integration
+// :include: //div[@class="slides"]
+// :header_footer:
+= MathJax
+:stem:
+:revealjsdir: https://cdn.jsdelivr.net/npm/reveal.js@3.9.2
+:mathjaxdir: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/
+
+== Math Equation
+
+Using standard latexmath:[\LaTeX] syntax:
+
+[stem]
+++++
+\sqrt{37} = \sqrt{\frac{73^2-1}{12^2}} \approx \frac{73}{12} (1 - \frac{1}{2\cdot73^2})
+++++
+
+Another one:
+
+stem:[\sum_{i=0}^n i^2 = \frac{(n^2+n)(2n+1)}{6}]


### PR DESCRIPTION
This adds an example file showing how to specify the `:mathjaxdir:` attribute, which works with a URL or a local path.