### PR TITLE
Fix broken documentation links, target reveal-js v3.9 branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,8 +18,9 @@ endif::[]
 :uri-project-repo: https://github.com/asciidoctor/asciidoctor-reveal.js
 :uri-asciidoctor: https://github.com/asciidoctor/asciidoctor
 :uri-asciidoctorjs: https://github.com/asciidoctor/asciidoctor.js
-:uri-revealjs-home: http://lab.hakim.se/reveal-js/
-:uri-revealjs-gh: https://github.com/hakimel/reveal.js
+:uri-revealjs-home: https://revealjs.com
+:uri-revealjs-gh: https://github.com/hakimel/reveal.js/blob/v3.9
+:uri-revealjs-doc: {uri-revealjs-gh}/README.md
 :uri-nodejs-download: https://nodejs.org/en/download/
 :showcasedir: showcase
 
@@ -314,7 +315,7 @@ A Great Story
 --
 ----
 
-In previous snippet we are creating a slide titled Slide One with bullets and another one titled Slide Two with centered text (reveal.js`' default behavior) with {uri-revealjs-gh}#speaker-notes[speaker notes].
+In previous snippet we are creating a slide titled Slide One with bullets and another one titled Slide Two with centered text (reveal.js`' default behavior) with {uri-revealjs-doc}#speaker-notes[speaker notes].
 Other syntax exists to create speaker notes, see `examples/speaker-notes.adoc`.
 
 Starting with Reveal.js 3.5 speaker notes supports configurable layouts:
@@ -401,7 +402,7 @@ NOTE: The `canvas` keyword can be used instead of `background` for the same effe
 Is very yellow
 ----
 
-Slide Three applies the attribute {uri-revealjs-gh}#slide-backgrounds[data-background-color] to the `reveal.js` <section> tag.
+Slide Three applies the attribute {uri-revealjs-doc}#slide-backgrounds[data-background-color] to the `reveal.js` <section> tag.
 Anything accepted by CSS color formats works.
 
 
@@ -418,7 +419,7 @@ image::cover.jpg[background, size=cover]
 This will put `cover.jpg` as the slide's background image.
 It sets reveal.js`' `data-background-image` attribute.
 The `size` attribute is also supported.
-See the {uri-revealjs-gh}#image-backgrounds[relevant reveal.js documentation] for details.
+See the {uri-revealjs-doc}#image-backgrounds[relevant reveal.js documentation] for details.
 
 NOTE: Background images file names are now relative to the `:imagesdir:` attribute if set.
 
@@ -456,7 +457,7 @@ For example:
 == Nice background!
 ----
 
-See {uri-revealjs-gh}#video-backgrounds[the relevant reveal.js documentation] for details.
+See {uri-revealjs-doc}#video-backgrounds[the relevant reveal.js documentation] for details.
 Note that the `data-` prefix is not required in asciidoc files.
 
 
@@ -470,7 +471,7 @@ The background can be replaced with anything a browser can render in an iframe u
 == a youtube video
 ----
 
-See {uri-revealjs-gh}#iframe-backgrounds[the relevant reveal.js documentation] for details.
+See {uri-revealjs-doc}#iframe-backgrounds[the relevant reveal.js documentation] for details.
 
 
 === Slide Transitions
@@ -488,7 +489,7 @@ This slide will override the presentation transition and zoom!
 Choose from three transition speeds: default, fast or slow!
 ----
 
-See {uri-revealjs-gh}#slide-transitions[the relevant reveal.js documentation] for details.
+See {uri-revealjs-doc}#slide-transitions[the relevant reveal.js documentation] for details.
 
 
 === Fragments
@@ -505,9 +506,9 @@ See {uri-revealjs-gh}#slide-transitions[the relevant reveal.js documentation] fo
 ----
 
 Slide Four has bullets that are revealed one after the other.
-This is what `reveal.js` calls http://lab.hakim.se/reveal-js/#/fragments[fragments].
+This is what `reveal.js` calls {uri-revealjs-home}/fragments[fragments].
 Applying the step option or role on a list (`[%step]` or `[.step]`) will do the trick.
-Here is {uri-revealjs-gh}#fragments[the relevant reveal.js
+Here is {uri-revealjs-doc}#fragments[the relevant reveal.js
 documentation] on the topic.
 Note that only `fade-in` is supported for lists at the moment.
 
@@ -523,7 +524,7 @@ To apply that class to block simply use asciidoctor's class assignment:
 
     [.stretch]
 
-See {uri-revealjs-gh}#stretching-elements[reveal.js documentation on stretching elements].
+See {uri-revealjs-doc}#stretching-elements[reveal.js documentation on stretching elements].
 
 
 === Videos
@@ -625,7 +626,7 @@ This is a vertical subslide
 
 Slide Six uses the vertical slide feature of `reveal.js`.
 Slide Six.One will be rendered vertically below Slide Six.
-Here is {uri-revealjs-gh}#markup[the relevant reveal.js
+Here is {uri-revealjs-doc}#markup[the relevant reveal.js
 documentation] on that topic.
 
 === Columns layout
@@ -808,7 +809,7 @@ title that look like this: `:name: value`.
 This converter supports changing the color, image, video, iframe and
 transitions of the title slide.
 
-Read {uri-revealjs-gh}#slide-backgrounds[the relevant reveal.js documentation] to understand what attributes need to be set.
+Read {uri-revealjs-doc}#slide-backgrounds[the relevant reveal.js documentation] to understand what attributes need to be set.
 Keep in mind that for title slides you must replace `data-` with `title-slide-`.
 
 ifeval::[{safe-mode-level} >= 20]
@@ -891,7 +892,7 @@ If the `:customcss:` attribute value is empty then `asciidoctor-revealjs.css` is
 
 === Slide state
 
-Reveal.js supports a {uri-revealjs-gh}#slide-states[data-state] tag that can be added on slides which gets rendered into `<section>` tags.
+Reveal.js supports a {uri-revealjs-doc}#slide-states[data-state] tag that can be added on slides which gets rendered into `<section>` tags.
 In AsciiDoc the `data-state` can be applied to a slide by adding a state attribute to a section like this:
 
 [source, asciidoc]
@@ -984,7 +985,7 @@ NOTE: Default settings are based on `reveal.js` default settings.
 
 |:revealjs_theme:
 |beige, *black*, league, night, serif, simple, sky, solarized, white
-|Chooses one of reveal.js`' {uri-revealjs-gh}#theming[built-in themes].
+|Chooses one of reveal.js`' {uri-revealjs-doc}#theming[built-in themes].
 
 |:revealjs_customtheme:
 |<file\|URL>
@@ -1076,7 +1077,7 @@ print:: only show slide numbers when printing to PDF
 
 |:revealjs_navigationMode:
 |*default*, linear, grid
-|See https://github.com/hakimel/reveal.js/#navigation-mode for details
+|See {uri-revealjs-doc}#navigation-mode for details
 
 |:revealjs_shuffle:
 |true, *false*
@@ -1251,14 +1252,14 @@ Defaults to *1*
 
 If you want to build a custom theme or customize an existing one you should
 look at the
-{uri-revealjs-gh}/blob/master/css/theme/README.md[reveal.js
+{uri-revealjs-gh}/css/theme/README.md[reveal.js
 theme documentation] and use the `revealjs_customtheme` AsciiDoc attribute to
 activate it.
 
 
 === PDF Export
 
-Follow https://github.com/hakimel/reveal.js#pdf-export[reveal.js' documentation] for PDF export.
+Follow {uri-revealjs-doc}#pdf-export[reveal.js' documentation] for PDF export.
 We would add that we have successfully used PDF export without the requirement of a Web server.
 
 
@@ -1292,7 +1293,7 @@ Additional reveal.js plugins can be installed and activated using AsciiDoc attri
 
 Looking at the example provided in the repository will provide guidance: link:examples/revealjs-plugins.adoc[AsciiDoc source], link:examples/revealjs-plugins.js[Plugin Loader], link:examples/revealjs-plugins-conf.js[Plugin Configuration].
 
-Read {uri-revealjs-gh}#dependencies[the relevant reveal.js documentation] to understand more about reveal.js plugins.
+Read {uri-revealjs-doc}#dependencies[the relevant reveal.js documentation] to understand more about reveal.js plugins.
 A {uri-revealjs-gh}/wiki/Plugins,-Tools-and-Hardware[list of existing reveal.js plugins] is also maintained upstream.
 
 


### PR DESCRIPTION
Fixes #371

- Introduce a new attribute `uri-revealjs-doc` that points to GitHub v3.9 README.md (note: with 4.0 it will have to point to `uri-revealjs-home`)
- Fix a few broken URLs that were not using the attributes.