### PR TITLE
add footnotes (per slide)

### DIFF
--- a/examples/footnotes.adoc
+++ b/examples/footnotes.adoc
@@ -1,0 +1,28 @@
+// .footnotes
+// :include: //div[@class="slides"]
+// :header_footer:
+= Presentation
+Author Name
+:revealjs_theme: simple
+:revealjs_transition: none
+:revealjs_hash: true
+
+== Introduction
+
+This is some text.footnote:[An example footnote.]
+
+== Press Release
+
+A statement.footnote:[Clarification about this statement.]
+
+A bold statement!footnote:disclaimer[Opinions are my own.]
+
+== Externalized Footnotes
+
+:fn-hail-and-rainbow: footnote:[The double hail-and-rainbow level makes my toes tingle.]
+:fn-disclaimer: footnote:disclaimer[Opinions are my own.]
+
+The hail-and-rainbow protocol can be initiated at five levels:
+double, tertiary, supernumerary, supermassive, and apocalyptic party.{fn-hail-and-rainbow}
+A bold statement!{fn-disclaimer}
+Another outrageous statement.{fn-disclaimer}

--- a/templates/asciidoctor-compatibility.css
+++ b/templates/asciidoctor-compatibility.css
@@ -1,73 +1,267 @@
-.reveal div.right{float:right}
+.reveal div.right {
+  float: right
+}
 
 /* listing block */
-.reveal .listingblock.stretch>.content{height: 100%}
-.reveal .listingblock.stretch>.content>pre{height: 100%}
-.reveal .listingblock.stretch>.content>pre>code{height:100%;max-height:100%}
+.reveal .listingblock.stretch > .content {
+  height: 100%
+}
+
+.reveal .listingblock.stretch > .content > pre {
+  height: 100%
+}
+
+.reveal .listingblock.stretch > .content > pre > code {
+  height: 100%;
+  max-height: 100%
+}
 
 /* tables */
-table{border-collapse:collapse;border-spacing:0}
-table{margin-bottom:1.25em;border:solid 1px #dedede}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-td.tableblock>.content{margin-bottom:1.25em}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-.reveal table th.halign-left,.reveal table td.halign-left{text-align:left}
-.reveal table th.halign-right,.reveal table td.halign-right{text-align:right}
-.reveal table th.halign-center,.reveal table td.halign-center{text-align:center}
-.reveal table th.valign-top,.reveal table td.valign-top{vertical-align:top}
-.reveal table th.valign-bottom,.reveal table td.valign-bottom{vertical-align:bottom}
-.reveal table th.valign-middle,.reveal table td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{font-weight:bold}
-thead{display:table-header-group}
+table {
+  border-collapse: collapse;
+  border-spacing: 0
+}
 
-.reveal table.grid-none th,.reveal table.grid-none td{border-bottom:0!important}
+table {
+  margin-bottom: 1.25em;
+  border: solid 1px #dedede
+}
+
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td {
+  padding: .5em .625em .625em;
+  font-size: inherit;
+  text-align: left
+}
+
+table tr th, table tr td {
+  padding: .5625em .625em;
+  font-size: inherit
+}
+
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td {
+  display: table-cell;
+  line-height: 1.6
+}
+
+td.tableblock > .content {
+  margin-bottom: 1.25em
+}
+
+td.tableblock > .content > :last-child {
+  margin-bottom: -1.25em
+}
+
+table.tableblock, th.tableblock, td.tableblock {
+  border: 0 solid #dedede
+}
+
+table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock {
+  border-width: 0 1px 1px 0
+}
+
+table.grid-all > tfoot > tr > .tableblock {
+  border-width: 1px 1px 0 0
+}
+
+table.grid-cols > * > tr > .tableblock {
+  border-width: 0 1px 0 0
+}
+
+table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock {
+  border-width: 0 0 1px
+}
+
+table.grid-rows > tfoot > tr > .tableblock {
+  border-width: 1px 0 0
+}
+
+table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child {
+  border-right-width: 0
+}
+
+table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock {
+  border-bottom-width: 0
+}
+
+table.frame-all {
+  border-width: 1px
+}
+
+table.frame-sides {
+  border-width: 0 1px
+}
+
+table.frame-topbot, table.frame-ends {
+  border-width: 1px 0
+}
+
+.reveal table th.halign-left, .reveal table td.halign-left {
+  text-align: left
+}
+
+.reveal table th.halign-right, .reveal table td.halign-right {
+  text-align: right
+}
+
+.reveal table th.halign-center, .reveal table td.halign-center {
+  text-align: center
+}
+
+.reveal table th.valign-top, .reveal table td.valign-top {
+  vertical-align: top
+}
+
+.reveal table th.valign-bottom, .reveal table td.valign-bottom {
+  vertical-align: bottom
+}
+
+.reveal table th.valign-middle, .reveal table td.valign-middle {
+  vertical-align: middle
+}
+
+table thead th, table tfoot th {
+  font-weight: bold
+}
+
+tbody tr th {
+  display: table-cell;
+  line-height: 1.6
+}
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p {
+  font-weight: bold
+}
+
+thead {
+  display: table-header-group
+}
+
+.reveal table.grid-none th, .reveal table.grid-none td {
+  border-bottom: 0 !important
+}
 
 /* kbd macro */
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
+kbd {
+  font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
+  display: inline-block;
+  color: rgba(0, 0, 0, .8);
+  font-size: .65em;
+  line-height: 1.45;
+  background: #f7f7f7;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, .2), 0 0 0 .1em white inset;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, .2), 0 0 0 .1em #fff inset;
+  margin: 0 .15em;
+  padding: .2em .5em;
+  vertical-align: middle;
+  position: relative;
+  top: -.1em;
+  white-space: nowrap
+}
+
+.keyseq kbd:first-child {
+  margin-left: 0
+}
+
+.keyseq kbd:last-child {
+  margin-right: 0
+}
 
 /* callouts */
-.conum[data-value] {display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:50%;border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]:after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
+.conum[data-value] {
+  display: inline-block;
+  color: #fff !important;
+  background: rgba(0, 0, 0, .8);
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+  text-align: center;
+  font-size: .75em;
+  width: 1.67em;
+  height: 1.67em;
+  line-height: 1.67em;
+  font-family: "Open Sans", "DejaVu Sans", sans-serif;
+  font-style: normal;
+  font-weight: bold
+}
+
+.conum[data-value] * {
+  color: #fff !important
+}
+
+.conum[data-value] + b {
+  display: none
+}
+
+.conum[data-value]:after {
+  content: attr(data-value)
+}
+
+pre .conum[data-value] {
+  position: relative;
+  top: -.125em
+}
+
+b.conum * {
+  color: inherit !important
+}
+
+.conum:not([data-value]):empty {
+  display: none
+}
+
 /* Callout list */
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.hdlist > table, .colist > table {
+  border: 0;
+  background: none
+}
+
+.hdlist > table > tbody > tr, .colist > table > tbody > tr {
+  background: none
+}
+
+td.hdlist1, td.hdlist2 {
+  vertical-align: top;
+  padding: 0 .625em
+}
+
+td.hdlist1 {
+  font-weight: bold;
+  padding-bottom: 1.25em
+}
+
 /* Disabled from Asciidoctor CSS because it caused callout list to go under the
  * source listing when .stretch is applied (see #335)
  * .literalblock+.colist,.listingblock+.colist{margin-top:-.5em} */
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
+.colist td:not([class]):first-child {
+  padding: .4em .75em 0;
+  line-height: 1;
+  vertical-align: top
+}
+
+.colist td:not([class]):first-child img {
+  max-width: none
+}
+
+.colist td:not([class]):last-child {
+  padding: .25em 0
+}
 
 /* Override Asciidoctor CSS that causes issues with reveal.js features */
-.reveal .hljs table{border: 0}
+.reveal .hljs table {
+  border: 0
+}
+
 /* Callout list rows would have a bottom border with some reveal.js themes (see #335) */
-.reveal .colist>table th, .reveal .colist>table td {border-bottom:0}
+.reveal .colist > table th, .reveal .colist > table td {
+  border-bottom: 0
+}
+
 /* Fixes line height with Highlight.js source listing when linenums enabled (see #331) */
-.reveal .hljs table thead tr th, .reveal .hljs table tfoot tr th, .reveal .hljs table tbody tr td, .reveal .hljs table tr td, .reveal .hljs table tfoot tr td{line-height:inherit}
+.reveal .hljs table thead tr th, .reveal .hljs table tfoot tr th, .reveal .hljs table tbody tr td, .reveal .hljs table tr td, .reveal .hljs table tfoot tr td {
+  line-height: inherit
+}
 
 /* Columns layout */
 .columns .slide-content {
@@ -186,4 +380,11 @@ td.hdlist1{font-weight:bold;padding-bottom:1.25em}
 
 .text-justify {
   text-align: justify !important
+}
+
+.footnotes {
+  border-top: 1px solid rgba(0, 0, 0, 0.2);
+  padding: 0.5em 0 0 0;
+  font-size: 0.65em;
+  margin-top: 4em;
 }

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -128,6 +128,29 @@ module Slim::Helpers
     @_section_level ||= (sec.level == 0 && sec.special) ? 1 : sec.level
   end
 
+  ##
+  # Display footnotes per slide
+  #
+  @@slide_footnotes = {}
+
+  def slide_footnote(footnote)
+    initial_index = footnote.attr(:index)
+    # reset the footnote numbering to 1 on each slide
+    # make sure that if a footnote is used more than once it will use the same index/number
+    slide_index = (existing_footnote = @@slide_footnotes[initial_index]) ? existing_footnote.attr(:index) : @@slide_footnotes.length + 1
+    attributes = footnote.attributes.merge({ 'index' => slide_index })
+    slide_footnote = Asciidoctor::Inline.new(footnote.parent, footnote.context, footnote.text, :attributes => attributes)
+    @@slide_footnotes[initial_index] = slide_footnote
+    slide_footnote
+  end
+
+  def clear_slide_footnotes
+    @@slide_footnotes = {}
+  end
+
+  def slide_footnotes
+    @@slide_footnotes.map { |_, footnote| Asciidoctor::Document::Footnote.new(footnote.attr(:index), footnote.id, footnote.text) }
+  end
 
   ##
   # Returns the captioned section's title, optionally numbered.

--- a/templates/inline_footnote.html.slim
+++ b/templates/inline_footnote.html.slim
@@ -1,6 +1,13 @@
+- footnote = slide_footnote(self)
+- index = footnote.attr(:index)
+- id = footnote.id
 - if @type == :xref
-  = html_tag('span', { :class => ['footnoteref'] }.merge(data_attrs(@attributes)))
-    | [<a class="footnote" href="#_footnote_#{attr :index}" title="View footnote.">#{attr :index}</a>]
+  = html_tag('sup', { :class => ['footnoteref'] }.merge(data_attrs(footnote.attributes)))
+    | [
+    span(class="footnote" title="View footnote.") = index
+    | ]
 - else
-  = html_tag('span', { :id => ("_footnote_#{@id}" if @id), :class => ['footnote'] }.merge(data_attrs(@attributes)))
-    | [<a id="_footnoteref_#{attr :index}" class="footnote" href="#_footnote_#{attr :index}" title="View footnote.">#{attr :index}</a>]
+  = html_tag('sup', { :id => ("_footnote_#{id}" if id), :class => ['footnote'] }.merge(data_attrs(footnote.attributes)))
+    | [
+    span(class="footnote" title="View footnote.") = index
+    | ]

--- a/templates/section.html.slim
+++ b/templates/section.html.slim
@@ -67,6 +67,11 @@
       - unless (_content = content.chomp).empty?
         div.slide-content
           =_content
+          - if document.footnotes? && !(parent.attr? 'nofootnotes') && !slide_footnotes.empty?
+            .footnotes
+              - slide_footnotes.each do |footnote|
+                .footnote
+                  = "#{footnote.index}. #{footnote.text}"
 
 / RENDERING
 / render parent section of vertical slides set
@@ -84,3 +89,5 @@
     =content.chomp
   - else
     - yield_content :section
+
+- clear_slide_footnotes

--- a/test/doctest/document.html
+++ b/test/doctest/document.html
@@ -66,10 +66,10 @@
 <div class="reveal">
   <div class="slides">
     <div class="paragraph">
-      <p>The hail-and-rainbow protocol can be initiated at five levels: double, tertiary, supernumerary, supermassive, and apocalyptic party.<span class="footnote">[<a class="footnote" href="#_footnote_1" id="_footnoteref_1" title="View footnote.">1</a>]</span> A bold statement.<span class="footnote" id="_footnote_disclaimer">[<a class="footnote" href="#_footnote_2" id="_footnoteref_2" title="View footnote.">2</a>]</span></p>
+      <p>The hail-and-rainbow protocol can be initiated at five levels: double, tertiary, supernumerary, supermassive, and apocalyptic party.<sup class="footnote">[<span class="footnote" title="View footnote.">1</span>]</sup> A bold statement.<sup class="footnote">[<span class="footnote" title="View footnote.">2</span>]</sup></p>
     </div>
     <div class="paragraph">
-      <p>Another outrageous statement.<span class="footnoteref">[<a class="footnote" href="#_footnote_2" title="View footnote.">2</a>]</span></p>
+      <p>Another outrageous statement.<sup class="footnoteref">[<span class="footnote" title="View footnote.">2</span>]</sup></p>
     </div>
   </div>
 </div>

--- a/test/doctest/embedded.html
+++ b/test/doctest/embedded.html
@@ -3,10 +3,10 @@
 
 <!-- .footnotes -->
 <div class="paragraph">
-  <p>The hail-and-rainbow protocol can be initiated at five levels: double, tertiary, supernumerary, supermassive, and apocalyptic party.<span class="footnote">[<a class="footnote" href="#_footnote_1" id="_footnoteref_1" title="View footnote.">1</a>]</span> A bold statement.<span class="footnote" id="_footnote_disclaimer">[<a class="footnote" href="#_footnote_2" id="_footnoteref_2" title="View footnote.">2</a>]</span></p>
+  <p>The hail-and-rainbow protocol can be initiated at five levels: double, tertiary, supernumerary, supermassive, and apocalyptic party.<sup class="footnote">[<span class="footnote" title="View footnote.">1</span>]</sup> A bold statement.<sup class="footnote">[<span class="footnote" title="View footnote.">2</span>]</sup></p>
 </div>
 <div class="paragraph">
-  <p>Another outrageous statement.<span class="footnoteref">[<a class="footnote" href="#_footnote_2" title="View footnote.">2</a>]</span></p>
+  <p>Another outrageous statement.<sup class="footnoteref">[<span class="footnote" title="View footnote.">2</span>]</sup></p>
 </div>
 <div id="footnotes">
   <hr>

--- a/test/doctest/footnotes.html
+++ b/test/doctest/footnotes.html
@@ -1,0 +1,50 @@
+<!-- .footnotes -->
+<div class="slides">
+  <section class="title" data-state="title">
+    <h1>Presentation</h1>
+    <p class="author"><small>Author Name</small></p>
+  </section>
+  <section id="_introduction">
+    <h2>Introduction</h2>
+    <div class="slide-content">
+      <div class="paragraph">
+        <p>This is some text.<sup class="footnote">[<span class="footnote" title="View footnote.">1</span>]</sup></p>
+      </div>
+      <div class="footnotes">
+        <div class="footnote">1. An example footnote.</div>
+      </div>
+    </div>
+  </section>
+  <section id="_press_release">
+    <h2>Press Release</h2>
+    <div class="slide-content">
+      <div class="paragraph">
+        <p>A statement.<sup class="footnote">[<span class="footnote" title="View footnote.">1</span>]</sup></p>
+      </div>
+      <div class="paragraph">
+        <p>A bold statement!<sup class="footnote">[<span class="footnote" title="View footnote.">2</span>]</sup></p>
+      </div>
+      <div class="footnotes">
+        <div class="footnote">1. Clarification about this statement.</div>
+        <div class="footnote">2. Opinions are my own.</div>
+      </div>
+    </div>
+  </section>
+  <section id="_externalized_footnotes">
+    <h2>Externalized Footnotes</h2>
+    <div class="slide-content">
+      <div class="paragraph">
+        <p>
+          The hail-and-rainbow protocol can be initiated at five levels: double, tertiary, supernumerary, supermassive, and apocalyptic party.<sup class="footnote">[<span class="footnote" title="View footnote.">1</span>]</sup>
+          A bold statement!<sup class="footnoteref">[<span class="footnote" title="View footnote.">2</span>]</sup>
+          Another outrageous statement.<sup class="footnoteref">[<span class="footnote" title="View footnote.">2</span>]</sup>
+        </p>
+      </div>
+      <div class="footnotes">
+        <div class="footnote">1. The double hail-and-rainbow level makes my toes tingle.</div>
+        <div class="footnote">2. Opinions are my own.</div>
+      </div>
+    </div>
+  </section>
+</div>
+


### PR DESCRIPTION
It's worth noting that when using reveal.js' default layout (vertically-centered slides), footnotes  will be display just after the content on each slide.

If you want to vertically align footnotes at the bottom of each slides, you will need to provide a custom CSS file. 

![notes](https://user-images.githubusercontent.com/333276/101180654-24569300-364c-11eb-9a6b-cdecc02c99fe.gif)


resolves #30 