### PR TITLE
Automate the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release Ruby
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v2.1.3
+
+jobs:
+  build_ruby:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: Configure Nokogiri installation (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          bundle config --local build__nokogiri --use-system-libraries
+          sudo apt-get install libxslt1-dev
+      - name: Install dependencies
+        run: bundle --jobs 3 --retry 3
+      - name: Build
+        run: bundle exec rake build
+      - name: Run tests
+        run: bundle exec rake test
+      - name: Run examples:convert
+        run: bundle exec rake examples:convert
+  publish_ruby:
+    needs: build_ruby
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: Install and build
+        run: |
+          bundle --jobs 3 --retry 3
+          bundle exec rake build
+      - name: Configure credentials
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}" > $HOME/.gem/credentials
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+      - name: Build gem
+        run: |
+          gem build asciidoctor-revealjs.gemspec
+      - name: Publish to rubygems.org
+        run: |
+          gem push asciidoctor-revealjs-${GITHUB_REF#refs/tags/ruby-v}.gem
+  publish_js:
+    needs: publish_ruby
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: Install and build
+        run: |
+          bundle --jobs 3 --retry 3
+          bundle exec rake build
+          bundle exec rake build:js
+      - name: Install dependencies
+        run: |
+          npm ci
+      - name: Test
+        run: |
+          npm t
+      - name: Package and publish
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm run package
+          npm publish
+      # create the GitHub release
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+      # upload binaries
+      - name: Upload Linux binary
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/reveal-linux
+          asset_name: asciidoctor-revealjs-linux
+          asset_content_type: application/octet-stream
+      - name: Upload macOS binary
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/reveal-macos
+          asset_name: asciidoctor-revealjs-macos
+          asset_content_type: application/octet-stream
+      - name: Upload Windows binary
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/reveal-win.exe
+          asset_name: asciidoctor-revealjs-win.exe
+          asset_content_type: application/octet-stream
+

--- a/docs/modules/project/pages/hacking.adoc
+++ b/docs/modules/project/pages/hacking.adoc
@@ -304,6 +304,7 @@ Then run:
 
 == Release process
 
+=== Prepare the release
 
 . Make sure that the highlight plugin code embed in _lib/asciidoctor-revealjs/highlightjs.rb_ is up-to-date with the version of reveal.js
 . Do we need to do anything regarding our Opal dependency and Asciidoctor.js?
@@ -338,6 +339,25 @@ See <<node-binary-compatibility,our section on the topic>>.
 . Tag the release commit
 ** Annotated Tag msg: Version %version%
 . Push your changes (including the tag)
+
+=== Release
+
+The release process is automated and relies on GitHub Actions.
+We are using personal tokens to publish to rubygems.org and npmjs.com.
+
+The `RUBYGEMS_API_KEY` and `NPM_TOKEN` secrets are configured on GitHub.
+See the `.github/workflows/release.yml` file for details.
+
+Once the https://github.com/asciidoctor/asciidoctor-reveal.js/actions?query=workflow%3Arelease[release workflow]
+has been completed:
+
+[%interactive]
+* [ ] Check that the new version is available on https://rubygems.org/gems/asciidoctor-revealjs[rubygems.org]
+* [ ] Check that the new version is available on https://www.npmjs.com/package/@asciidoctor/reveal.js[npmjs.com]
+* [ ] Check that a https://github.com/asciidoctor/asciidoctor-reveal.js/releases[release has been created on GitHub].
+* [ ] Update the GitHub release (using the CHANGELOG.adoc and the previous release as a template)
+
+////
 . Make a release on github (from changelog and copy from previous releases)
 ** Useful vim regex for AsciiDoc to Markdown:
 +
@@ -353,8 +373,9 @@ See <<node-binary-compatibility,our section on the topic>>.
  $ bundle exec rake build
  $ gem build asciidoctor-revealjs.gemspec
  $ gem push asciidoctor-revealjs-X.Y.Z.gem
+////
 
-. Check that the new version is available on https://rubygems.org/gems/asciidoctor-revealjs[rubygems.org]
+////
 . Generate the javascript version of the Ruby converter
 +
  $ bundle exec rake build:js
@@ -363,19 +384,30 @@ See <<node-binary-compatibility,our section on the topic>>.
 +
  $ npm login # only required if not already authenticated
  $ npm publish
+////
 
-. Check that the new version is available on https://www.npmjs.com/package/@asciidoctor/reveal.js[npmjs.com]
+////
 . Make binaries release
 ** Run `npm run package`. Binaries built will be in `dist/`. Upload them to the GitHub release page.
 . Publish previously saved GitHub release draft
-. Update version in `lib/asciidoctor-revealjs/version.rb` and `package.json` (+1 bugfix and append '-dev')
+////
+
+=== Prepare next version
+
+. If you just released a major or minor version, create and push a maintenance branch for the previous version.
+For instance, if the previous version was 4.3.2, create a branch named: `4.3.x`.
+** Modify the Antora playbook to add this branch: https://github.com/asciidoctor/docs.asciidoctor.org/edit/main/antora-playbook.yml
+
+. On the master branch, update version in `docs/antora.yml`
+. On the master branch, update version in `lib/asciidoctor-revealjs/version.rb` and `package.json` (+1 bugfix and append '-dev')
 ** Remove the "Slim compiled to Ruby" converter to the git tree (to avoid noise to the repo and `git status` noise)
 +
     git rm --cached lib/asciidoctor-revealjs/converter.rb
 
 ** commit msg: Begin development on next release
-. Submit a PR upstream to sync the documentation on asciidoctor.org
-** Modify this page: https://github.com/asciidoctor/asciidoctor.org/edit/master/docs/asciidoctor-revealjs.adoc
+
+=== Downstream projects
+
 . Submit a PR downstream to update Asciidoctor reveal.js version inside docker-asciidoctor
 ** Modify the `Dockerfile`, `Makefile` and `README.adoc` of: https://github.com/asciidoctor/docker-asciidoctor
 . Submit a PR downstream to update AsciidoctorJ reveal.js version

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@asciidoctor/core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.1.1.tgz",
-      "integrity": "sha512-yzV8GvrVUZst/lAlDvvEWY9Na9YhevE7PE3k1SvtQNyJEnpTWoKHrPG3soQ95nPM4oh2USMjpKDh4cEbvIRZpw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.1.tgz",
+      "integrity": "sha512-wdVseZjCcBvFfWSsCGyyvJkSQJ9UmXDdTDKnL+HerM12XQq4eWtk7lniSIKO459ipqImcsrueib47EtkzzRjLw==",
       "dev": true,
       "requires": {
         "asciidoctor-opal-runtime": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "reveal.js": "3.9.2"
   },
   "devDependencies": {
-    "@asciidoctor/core": "^2.1.1",
+    "@asciidoctor/core": "^2.2.1",
     "bestikk-log": "0.1.0",
     "expect.js": "0.3.1",
     "pkg": "^4.4.2"


### PR DESCRIPTION
The next step will be to create a Rake (or npm) task to prepare the release and another one to prepare the next release.

We should also create a task to generate the GitHub release from the CHANGELOG. That would probably require to convert the CHANGELOG to Markdown (otherwise we will need to convert it from AsciiDoc to Markdown).

The complete release process:

```
$ bundle exec rake release:prepare 1.2.3
$ git push origin master --tags
$ bundle exec rake release:next 1.2.4
```