### PR TITLE
Drop thread_safe and concurrent-ruby dependencies

### DIFF
--- a/asciidoctor-revealjs.gemspec
+++ b/asciidoctor-revealjs.gemspec
@@ -31,8 +31,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'asciidoctor', ['>= 2.0.0', '< 3.0.0']
-  s.add_runtime_dependency 'thread_safe', '~> 0.3.5'
-  s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 
   s.add_development_dependency 'rake', '~> 13.0.0'
   s.add_development_dependency 'asciidoctor-doctest', '= 2.0.0.beta.7'


### PR DESCRIPTION
Seems like they serve no purpose in asciidoctor-reveal.js and most likely are artifacts from ancient Ruby versions 