### PR TITLE
Add documentation on how to use highlights

### DIFF
--- a/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
+++ b/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
@@ -128,7 +128,7 @@ public class TestClass {
 
 WARNING: The highlighting only works using the default source code highlighter https://highlightjs.org/[Highlight.js].
 
-NOTE: You can also use  `highlight=6-8` as an alternative to `highlight=6..8`.
+NOTE: You can also use `highlight=6-8` as an alternative to `highlight=6..8`.
 
 Finally, it is also possible to use https://revealjs.com/code/#step-by-step-highlights[step-by-step Highlights] by separating the different highlights with a pipe (`|`) symbol. For example:
 

--- a/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
+++ b/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
@@ -70,7 +70,7 @@ They are considered unsupported by the asciidoctor-reveal.js project.
 
 == Line number highlights
 
-Reveal.js can add https://revealjs.com/code/#line-numbers-%26-highlights[Line Numbers & Highlights] to source code blocks.
+reveal.js can add https://revealjs.com/code/#line-numbers-%26-highlights[Line Numbers & Highlights] to source code blocks.
 
 This example `source` block renders with no line numbers by default:
 

--- a/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
+++ b/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
@@ -108,7 +108,7 @@ public class TestClass {
 ----
 -----
 
-It is also possible to highlight only part of the source by using `highlight`. This will highlight the `testMethod()` code:
+It is also possible to highlight only part of the source by using `highlight`. This will highlight the whole `testMethod()` method:
 
 [source, asciidoc]
 -----

--- a/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
+++ b/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
@@ -128,7 +128,7 @@ public class TestClass {
 
 NOTE: You can also use  `highlight=6-8` as an alternative to `highlight=6..8`.
 
-Finally, it is also possible to use https://revealjs.com/code/#step-by-step-highlights[Step-by-step Highlights] by seperating the different highlights with a pipe (`|`) symbol. For example:
+Finally, it is also possible to use https://revealjs.com/code/#step-by-step-highlights[step-by-step Highlights] by separating the different highlights with a pipe (`|`) symbol. For example:
 
 [source, asciidoc]
 -----

--- a/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
+++ b/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
@@ -67,3 +67,83 @@ Alternatively, you can use http://rouge.jneen.net/[Rouge], http://coderay.rubych
 if you are using the Asciidoctor/Ruby/Bundler toolchain (not Asciidoctor.js/JavaScript/npm).
 Check the `examples/` directory for examples and notes about what needs to be done for them to work.
 They are considered unsupported by the asciidoctor-reveal.js project.
+
+== Line number highlights
+
+Reveal.js can add https://revealjs.com/code/#line-numbers-%26-highlights[Line Numbers & Highlights] to source code blocks.
+
+This example `source` block renders with no line numbers by default:
+
+[source, asciidoc]
+-----
+[source,java]
+----
+public class TestClass {
+    public TestClass() {
+
+    }
+
+    public void testMethod() {
+
+    }
+}
+----
+-----
+
+By adding `highlight`, line numbers will be added:
+
+[source, asciidoc]
+-----
+[source,java,highlight]
+----
+public class TestClass {
+    public TestClass() {
+
+    }
+
+    public void testMethod() {
+
+    }
+}
+----
+-----
+
+It is also possible to highlight only part of the source. This will highlight the `testMethod()` code:
+
+[source, asciidoc]
+-----
+[source,java,highlight=6..8]
+----
+public class TestClass {
+    public TestClass() {
+
+    }
+
+    public void testMethod() {
+
+    }
+}
+----
+-----
+
+NOTE: You can also use  `highlight=6-8` as an alternative to `highlight=6..8`.
+
+Finally, it is also possible to use https://revealjs.com/code/#step-by-step-highlights[Step-by-step Highlights] by seperating the different highlights with a pipe (`|`) symbol. For example:
+
+[source, asciidoc]
+-----
+[source,java,highlight='1..9|2..4|6..8']
+----
+public class TestClass {
+    public TestClass() {
+
+    }
+
+    public void testMethod() {
+
+    }
+}
+----
+-----
+
+This will first highlight the complete source block, then the constructor code on lines 2 to 4, and finally, the method code on lines 6 to 8.

--- a/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
+++ b/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
@@ -90,11 +90,11 @@ public class TestClass {
 ----
 -----
 
-By adding `highlight`, line numbers will be added:
+By adding `linenums`, line numbers will be added:
 
 [source, asciidoc]
 -----
-[source,java,highlight]
+[source,java,linenums]
 ----
 public class TestClass {
     public TestClass() {
@@ -108,11 +108,11 @@ public class TestClass {
 ----
 -----
 
-It is also possible to highlight only part of the source. This will highlight the `testMethod()` code:
+It is also possible to highlight only part of the source by using `highlight`. This will highlight the `testMethod()` code:
 
 [source, asciidoc]
 -----
-[source,java,highlight=6..8]
+[source,java,linenums,highlight=6..8]
 ----
 public class TestClass {
     public TestClass() {
@@ -125,6 +125,8 @@ public class TestClass {
 }
 ----
 -----
+
+WARNING: The highlighting only works using the default source code formatter https://highlightjs.org/[highlight.js].
 
 NOTE: You can also use  `highlight=6-8` as an alternative to `highlight=6..8`.
 
@@ -147,3 +149,5 @@ public class TestClass {
 -----
 
 This will first highlight the complete source block, then the constructor code on lines 2 to 4, and finally, the method code on lines 6 to 8.
+
+NOTE: Line numbers are always added if you use `highlight`. In that case, you can leave out `linenums`.

--- a/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
+++ b/docs/modules/converter/pages/syntax/syntax-highlighting.adoc
@@ -126,7 +126,7 @@ public class TestClass {
 ----
 -----
 
-WARNING: The highlighting only works using the default source code formatter https://highlightjs.org/[highlight.js].
+WARNING: The highlighting only works using the default source code highlighter https://highlightjs.org/[Highlight.js].
 
 NOTE: You can also use  `highlight=6-8` as an alternative to `highlight=6..8`.
 


### PR DESCRIPTION
The goal for this change is to document how to highlight (parts of) source code blocks. I had a hard time figuring it out if it was possible and how to do it. So hopefully, this will help future users to figure it out more easily.