### PR TITLE
Mention in the doc that revealjsdir can be a CDN

### DIFF
--- a/docs/modules/setup/pages/standalone-executable.adoc
+++ b/docs/modules/setup/pages/standalone-executable.adoc
@@ -34,7 +34,7 @@ If you don't have an existing presentation, you can create a sample presentation
 [source,asciidoc]
 ----
 = Title Slide
-:revealjsdir: reveal.js
+:revealjsdir:  https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.0
 
 == Slide One
 

--- a/docs/modules/setup/pages/standalone-executable.adoc
+++ b/docs/modules/setup/pages/standalone-executable.adoc
@@ -34,7 +34,7 @@ If you don't have an existing presentation, you can create a sample presentation
 [source,asciidoc]
 ----
 = Title Slide
-:revealjsdir:  reveal.js
+:revealjsdir: reveal.js
 
 == Slide One
 

--- a/docs/modules/setup/pages/standalone-executable.adoc
+++ b/docs/modules/setup/pages/standalone-executable.adoc
@@ -34,7 +34,7 @@ If you don't have an existing presentation, you can create a sample presentation
 [source,asciidoc]
 ----
 = Title Slide
-:revealjsdir:  https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.0
+:revealjsdir:  reveal.js
 
 == Slide One
 
@@ -49,3 +49,5 @@ To convert the sample presentation into slides, open a terminal and type:
 
 The above command will generate a file named [.path]_presentation.html_.
 You can open this file in a browser.
+
+TIP: Alternatively you can use `:revealjsdir: https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.0` to avoid having to setup reveal.js locally. Just be aware that then if you have no access to internet then the presentation will not load properly.


### PR DESCRIPTION
took me while to figure out that to actually use the standalone in a standalone manner you should use  
https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.0as opposed to look up using npm install etc. 

suggesting to use the cdn  location so the output is standalone and can be run and used with nothing else than the asciidoctor-revealjs binary.