### PR TITLE
resolves #31 add more complete author information

### DIFF
--- a/templates/asciidoctor-compatibility.css
+++ b/templates/asciidoctor-compatibility.css
@@ -388,3 +388,13 @@ td.hdlist1 {
   font-size: 0.65em;
   margin-top: 4em;
 }
+
+.byline {
+  font-size:.8em
+}
+ul.byline {
+  list-style-type: none;
+}
+ul.byline li + li {
+  margin-top: 0.25em;
+}

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -278,6 +278,42 @@ module Slim::Helpers
     end
     nil
   end
+
+  # Copied from asciidoctor/lib/asciidoctor/converter/semantic-html5.rb which is not yet shipped
+  # @todo remove this code when the new converter becomes available in the main gem
+  def generate_authors node
+    return if node.authors.empty?
+
+    if node.authors.length == 1
+      %(<p class="byline">
+#{format_author node, node.authors.first}
+</p>)
+    else
+      result = ['<ul class="byline">']
+      node.authors.each do |author|
+        result << "<li>#{format_author node, author}</li>"
+      end
+      result << '</ul>'
+      result.join Asciidoctor::LF
+    end
+  end
+
+  # Copied from asciidoctor/lib/asciidoctor/converter/semantic-html5.rb which is not yet shipped
+  # @todo remove this code when the new converter becomes available in the main gem
+  def format_author node, author
+    in_context 'author' do
+      %(<span class="author">#{node.sub_replacements author.name}#{author.email ? %( #{node.sub_macros author.email}) : ''}</span>)
+    end
+  end
+
+  # Copied from asciidoctor/lib/asciidoctor/converter/semantic-html5.rb which is not yet shipped
+  # @todo remove this code when the new converter becomes available in the main gem
+  def in_context name
+    (@convert_context ||= []).push name
+    result = yield
+    @convert_context.pop
+    result
+  end
   #--
 end
 

--- a/templates/title_slide.html.slim
+++ b/templates/title_slide.html.slim
@@ -24,5 +24,4 @@ section.title(class = role
   - preamble = @document.find_by context: :preamble
   - unless preamble.nil? or preamble.length == 0
     div.preamble=preamble.pop.content
-  - unless author.nil?
-    p.author: small=author
+  = generate_authors(@document)

--- a/test/doctest/document.html
+++ b/test/doctest/document.html
@@ -12,7 +12,7 @@
 <title>The Dangerous and Thrilling Documentation Chronicles</title><meta content="Kismet Rainbow Chameleon" name="author">
 <section class="title" data-state="title">
   <h1>The Dangerous and Thrilling Documentation Chronicles</h1>
-  <p class="author"><small>Kismet Rainbow Chameleon</small></p>
+  <p class="byline"><span class="author">Kismet Rainbow Chameleon</span></p>
 </section>
 
 <!-- .title-with-author
@@ -21,7 +21,7 @@
 <title>The Dangerous and Thrilling Documentation Chronicles</title><meta content="Kismet Rainbow Chameleon" name="author">
 <section class="title" data-state="title">
   <h1>The Dangerous and Thrilling Documentation Chronicles</h1>
-  <p class="author"><small>Kismet Rainbow Chameleon</small></p>
+  <p class="byline"><span class="author">Kismet Rainbow Chameleon <a href="mailto:kismet@asciidoctor.org">kismet@asciidoctor.org</a></span></p>
 </section>
 
 <!-- .title-with-multiple-authors
@@ -30,7 +30,10 @@
 <title>The Dangerous and Thrilling Documentation Chronicles</title><meta content="Kismet Rainbow Chameleon" name="author">
 <section class="title" data-state="title">
   <h1>The Dangerous and Thrilling Documentation Chronicles</h1>
-  <p class="author"><small>Kismet Rainbow Chameleon</small></p>
+  <ul class="byline">
+    <li><span class="author">Kismet Rainbow Chameleon <a href="mailto:kismet@asciidoctor.org">kismet@asciidoctor.org</a></span></li>
+    <li><span class="author">Lazarus het Draeke <a href="mailto:lazarus@asciidoctor.org">lazarus@asciidoctor.org</a></span></li>
+  </ul>
 </section>
 
 <!-- .title-with-revnumber
@@ -39,7 +42,7 @@
 <title>Document Title</title><meta content="Kismet Chameleon" name="author">
 <section class="title" data-state="title">
   <h1>Document Title</h1>
-  <p class="author"><small>Kismet Chameleon</small></p>
+  <p class="byline"><span class="author">Kismet Chameleon</span></p>
 </section>
 
 <!-- .title-with-revdate
@@ -48,7 +51,7 @@
 <title>Document Title</title><meta content="Kismet Chameleon" name="author">
 <section class="title" data-state="title">
   <h1>Document Title</h1>
-  <p class="author"><small>Kismet Chameleon</small></p>
+  <p class="byline"><span class="author">Kismet Chameleon</span></p>
 </section>
 
 <!-- .title-with-revremark
@@ -57,7 +60,7 @@
 <title>Document Title</title><meta content="Kismet Chameleon" name="author">
 <section class="title" data-state="title">
   <h1>Document Title</h1>
-  <p class="author"><small>Kismet Chameleon</small></p>
+  <p class="byline"><span class="author">Kismet Chameleon</span></p>
 </section>
 
 <!-- .footnotes

--- a/test/doctest/footnotes.html
+++ b/test/doctest/footnotes.html
@@ -2,7 +2,7 @@
 <div class="slides">
   <section class="title" data-state="title">
     <h1>Presentation</h1>
-    <p class="author"><small>Author Name</small></p>
+    <p class="byline"><span class="author">Author Name</span></p>
   </section>
   <section id="_introduction1">
     <h2>

--- a/test/doctest/multi-destination-content.html
+++ b/test/doctest/multi-destination-content.html
@@ -2,7 +2,7 @@
 <div class="slides">
   <section class="title" data-state="title">
     <h1>My Doc</h1>
-    <p class="author"><small>John Doe</small></p>
+    <p class="byline"><span class="author">John Doe <a href="mailto:John@example.net">John@example.net</a></span></p>
   </section>
   <section>
     <section id="_main_section">

--- a/test/doctest/revealjs-plugin-activation.html
+++ b/test/doctest/revealjs-plugin-activation.html
@@ -2,7 +2,7 @@
 <div class="slides">
   <section class="title" data-state="title">
     <h1>Default Plugins Changes</h1>
-    <p class="author"><small>Author</small></p>
+    <p class="byline"><span class="author">Author</span></p>
   </section>
   <section id="_slide_1">
     <h2>Slide 1</h2>

--- a/test/doctest/revealjs-plugins.html
+++ b/test/doctest/revealjs-plugins.html
@@ -2,7 +2,7 @@
 <div class="slides">
   <section class="title" data-state="title">
     <h1>Custom Plugins</h1>
-    <p class="author"><small>Author</small></p>
+    <p class="byline"><span class="author">Author</span></p>
   </section>
   <section id="_slide_1">
     <h2>Slide 1</h2>

--- a/test/doctest/title-preamble.html
+++ b/test/doctest/title-preamble.html
@@ -7,7 +7,7 @@
         <p>Preamble</p>
       </div>
     </div>
-    <p class="author"><small>Author Name</small></p>
+    <p class="byline"><span class="author">Author Name</span></p>
   </section>
   <section id="_slide_2">
     <h2>Slide 2</h2>


### PR DESCRIPTION
Should fix https://github.com/asciidoctor/asciidoctor-reveal.js/issues/31 and https://github.com/asciidoctor/asciidoctor-reveal.js/issues/122 , I've adapted the proposed code adapted from what I saw in the html5 converter, tell me if I should adapt the style.

Among the propositions I've used a `br` to separate the authors because a `&middot;` would make the line wraps on my screen, I didn't add a custom class to the `br` because I though the `authors` class of the parent `p` should make it easy enough to customize, but I can change it if you prefer.