### PR TITLE
Update MathJax support to version 3

### DIFF
--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -49,22 +49,24 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
     - if attr? :stem
       - eqnums_val = (attr 'eqnums', 'none')
       - eqnums_val = 'AMS' if eqnums_val == ''
-      - eqnums_opt = %( equationNumbers: { autoNumber: "#{eqnums_val}" } )
-      - mathjaxdir = (attr 'mathjaxdir', "#{cdn_base}/mathjax/2.7.6")
-      script type='text/x-mathjax-config'
-        | MathJax.Hub.Config({
-          tex2jax: {
+      - mathjaxdir = (attr 'mathjaxdir', "#{cdn_base}/mathjax/3.2.0/es5")
+      script
+        | window.MathJax = {
+          tex: {
             inlineMath: [#{Asciidoctor::INLINE_MATH_DELIMITERS[:latexmath].to_s}],
             displayMath: [#{Asciidoctor::BLOCK_MATH_DELIMITERS[:latexmath].to_s}],
-            ignoreClass: "nostem|nolatexmath"
+            tags: '#{eqnums_val}'
           },
-          asciimath2jax: {
+          options: {
+            ignoreClass: 'nostem|nolatexmath'
+          },
+          asciimath: {
             delimiters: [#{Asciidoctor::BLOCK_MATH_DELIMITERS[:asciimath].to_s}],
-            ignoreClass: "nostem|noasciimath"
           },
-          TeX: {#{eqnums_opt}}
-          });
-      script src='#{mathjaxdir}/MathJax.js?config=TeX-MML-AM_HTMLorMML'
+          loader: {
+            load: ['input/asciimath', 'output/chtml']
+          }};
+      script(async src='#{mathjaxdir}/tex-mml-chtml.js')
 
     - syntax_hl = self.syntax_highlighter
     - if syntax_hl && (syntax_hl.docinfo? :head)

--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -46,28 +46,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
           link rel='stylesheet' href=%(#{cdn_base}/font-awesome/#{font_awesome_version}/css/v4-shims.min.css)
       - else
         link rel='stylesheet' href=(normalize_web_path %(#{attr 'iconfont-name', 'font-awesome'}.css), (attr 'stylesdir', ''), false)
-    - if attr? :stem
-      - eqnums_val = (attr 'eqnums', 'none')
-      - eqnums_val = 'AMS' if eqnums_val == ''
-      - mathjaxdir = (attr 'mathjaxdir', "#{cdn_base}/mathjax/3.2.0/es5")
-      script
-        | window.MathJax = {
-          tex: {
-            inlineMath: [#{Asciidoctor::INLINE_MATH_DELIMITERS[:latexmath].to_s}],
-            displayMath: [#{Asciidoctor::BLOCK_MATH_DELIMITERS[:latexmath].to_s}],
-            tags: '#{eqnums_val}'
-          },
-          options: {
-            ignoreClass: 'nostem|nolatexmath'
-          },
-          asciimath: {
-            delimiters: [#{Asciidoctor::BLOCK_MATH_DELIMITERS[:asciimath].to_s}],
-          },
-          loader: {
-            load: ['input/asciimath', 'output/chtml']
-          }};
-      script(async src='#{mathjaxdir}/tex-mml-chtml.js')
-
+    = generate_stem(cdn_base)
     - syntax_hl = self.syntax_highlighter
     - if syntax_hl && (syntax_hl.docinfo? :head)
       =syntax_hl.docinfo :head, self, cdn_base_url: cdn_base, linkcss: linkcss, self_closing_tag_slash: '/'

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -325,13 +325,14 @@ module Slim::Helpers
     'all'
   ]
 
+  MATHJAX_VERSION = "3.2.0"
+
   # Generate the Mathjax markup to process STEM expressions
   # @param cdn_base [String]
   # @return [String]
   def generate_stem(cdn_base)
     if attr?(:stem)
-      eqnums_val = attr('eqnums', STEM_EQNUMS_NONE)
-      eqnums_val = STEM_EQNUMS_AMS if eqnums_val == ''
+      eqnums_val = attr('eqnums', STEM_EQNUMS_NONE).downcase
       unless STEM_EQNUMS_VALID_VALUES.include?(eqnums_val)
         eqnums_val = STEM_EQNUMS_AMS
       end
@@ -352,7 +353,7 @@ module Slim::Helpers
           load: ['input/asciimath', 'output/chtml', 'ui/menu']
         }
       }
-      mathjaxdir = attr('mathjaxdir', "#{cdn_base}/mathjax/3.2.0/es5")
+      mathjaxdir = attr('mathjaxdir', "#{cdn_base}/mathjax/#{MATHJAX_VERSION}/es5")
       %(<script>window.MathJax = #{JSON.generate(mathjax_configuration)};</script>) +
       %(<script async src="#{mathjaxdir}/tex-mml-chtml.js"></script>)
     end

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -325,7 +325,7 @@ module Slim::Helpers
     'all'
   ]
 
-  MATHJAX_VERSION = "3.2.0"
+  MATHJAX_VERSION = '3.2.0'
 
   # Generate the Mathjax markup to process STEM expressions
   # @param cdn_base [String]

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -333,7 +333,7 @@ module Slim::Helpers
       eqnums_val = attr('eqnums', STEM_EQNUMS_NONE)
       eqnums_val = STEM_EQNUMS_AMS if eqnums_val == ''
       unless STEM_EQNUMS_VALID_VALUES.include?(eqnums_val)
-        raise ::ArgumentError, %(Invalid eqnums value [#{eqnums_val}], valid values are #{STEM_EQNUMS_VALID_VALUES.join(', ')})
+        eqnums_val = STEM_EQNUMS_AMS
       end
       mathjax_configuration = {
         tex: {

--- a/templates/helpers.rb
+++ b/templates/helpers.rb
@@ -326,7 +326,7 @@ module Slim::Helpers
   ]
 
   # Generate the Mathjax markup to process STEM expressions
-  # @param [String] cdn_base
+  # @param cdn_base [String]
   # @return [String]
   def generate_stem(cdn_base)
     if attr?(:stem)


### PR DESCRIPTION
Intended to implement https://github.com/asciidoctor/asciidoctor-reveal.js/issues/369
The configuration format changed so I adapted it using https://mathjax.github.io/MathJax-demos-web/convert-configuration/convert-configuration.html and reading the doc.

These are the documents I used for my tests: 

```
= Asciimath
:stem:

== Slide

[stem]
++++
(a + b)^2 = a^2 + 2ab + b^2
++++
```

```
= Latexmath no num
:stem: latexmath

== Slide

[stem]
++++
(a + b)^2 = a^2 + 2ab + b^2
++++

[stem]
++++
(a + b)^2 = a^2 + 2ab + b^2
++++
```

```
= Latexmath num
:stem: latexmath
:eqnums: all

== Slide

[stem]
++++
(a + b)^2 = a^2 + 2ab + b^2
++++

[stem]
++++
(a + b)^2 = a^2 + 2ab + b^2
++++
```

```
= Latexmath num ams
firstname1 middlename1 lastname1 <email1@example.net>
2017-01-31
:stem: latexmath
:eqnums: ams

== Slide

[stem]
++++
(a + b)^2 = a^2 + 2ab + b^2
++++

[stem]
++++
(a + b)^2 = a^2 + 2ab + b^2
++++
```

```
= No stem
firstname1 middlename1 lastname1 <email1@example.net>
2017-01-31

== Slide

Content
```

With this change asciidoctor-reveal.js would use MathJax 3 but asciidoctor still use MathJax 2 (see https://github.com/asciidoctor/asciidoctor/issues/3449), I don't know if having different versions is a problem.