### PR TITLE
Update commands to avoid deprecated messages

### DIFF
--- a/docs/modules/setup/pages/ruby-setup.adoc
+++ b/docs/modules/setup/pages/ruby-setup.adoc
@@ -41,8 +41,9 @@ NOTE: For some reason, when you use the system Ruby on Fedora, you also have to 
 . Install the gems into the project
 
   $ bundle config --local github.https true
-  $ bundle --path=.bundle/gems --binstubs=.bundle/.bin
-
+  $ bundle config set --local path '.bundle/gems'
+	$ bundle binstubs --all
+  
 . Optional: Copy or clone reveal.js presentation framework.
 Allows you to modify themes or view slides offline.
 

--- a/docs/modules/setup/pages/ruby-setup.adoc
+++ b/docs/modules/setup/pages/ruby-setup.adoc
@@ -42,7 +42,7 @@ NOTE: For some reason, when you use the system Ruby on Fedora, you also have to 
 
   $ bundle config --local github.https true
   $ bundle config set --local path '.bundle/gems'
-	$ bundle binstubs --all
+  $ bundle binstubs --all
   
 . Optional: Copy or clone reveal.js presentation framework.
 Allows you to modify themes or view slides offline.


### PR DESCRIPTION
To avoid the deprecated messages:
```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path '.bundle/gems'`, and stop using this flag
[DEPRECATED] The --binstubs option will be removed in favor of `bundle binstubs --all`
```