### PR TITLE
resolves #469 improve Ruby set up instructions

### DIFF
--- a/docs/modules/setup/pages/ruby-setup.adoc
+++ b/docs/modules/setup/pages/ruby-setup.adoc
@@ -1,53 +1,57 @@
 = Ruby Setup
 :navtitle: Ruby
+:url-bundler: https://bundler.io
+:url-gh-pages: https://pages.github.com
+:url-project-templates: https://github.com/asciidoctor/asciidoctor-reveal.js/tree/maint-4.1.x/templates
 
-NOTE: To ensure repeatability, we recommend that you manage your presentation projects using http://bundler.io/[bundler].
+NOTE: To ensure repeatability, we recommend that you manage your presentation projects using {url-bundler}[Bundler^].
 
 == Prerequisites
 
-. Install http://bundler.io/[bundler] (if not already installed) using your system's package manager or with:
+If you manage Ruby using https://rvm.io[RVM] (as recommended), make sure you switch to the default Ruby version and gemset:
+
+  $ rvm use default
+
+If you've installed Ruby using RVM, you should already have {url-bundler}[Bundler^] installed.
+You can verify this using the following command:
+
+  $ bundle -v
+
+If Bundler is not installed, you can install it using the following command:
 
   $ gem install bundler
 
-. If you're using RVM, make sure you switch away from any gemset:
-
-  $ rvm use default
-+
-or
-+
-  $ rvm use system
-
+You're now ready to install Asciidoctor reveal.js.
 
 == Install
 
 NOTE: These instructions should be repeated for every presentation project.
 
-. Create project directory
+. Create a project directory
 
   $ mkdir my-awesome-presentation
   $ cd my-awesome-presentation
 
-. Create a file named `Gemfile` with the following content:
+. In that directory, create a file named `Gemfile` with the following contents:
 +
 [source,ruby]
 ----
 source 'https://rubygems.org'
 
-gem 'asciidoctor-revealjs' # latest released version
+gem 'asciidoctor-revealjs' # <.>
 ----
-+
-NOTE: For some reason, when you use the system Ruby on Fedora, you also have to add the json gem to the Gemfile.
-+
-. Install the gems into the project
+<.> Installs the latest released version of the asciidoctor-revealjs gem
 
-  $ bundle config --local github.https true
-  $ bundle config set --local path '.bundle/gems'
-  $ bundle binstubs --all
-  
-. Optional: Copy or clone reveal.js presentation framework.
-Allows you to modify themes or view slides offline.
+. Install the gems into the project using Bundler
+
+  $ bundle config --local path .bundle/gems
+  $ bundle
+
+. (Optional) Copy or clone reveal.js presentation framework
 
   $ git clone -b 3.9.2 --depth 1 https://github.com/hakimel/reveal.js.git
++
+This step allows you to modify themes or view slides offline.
 
 == Rendering the AsciiDoc into slides
 
@@ -57,14 +61,14 @@ See examples on the xref:converter:features.adoc[Features page] to get started.
 . Generate HTML presentation from the AsciiDoc source
 
   $ bundle exec asciidoctor-revealjs \
-    -a revealjsdir=https://cdn.jsdelivr.net/npm/reveal.js@3.9.2 CONTENT_FILE.adoc
+    -a revealjsdir=https://cdn.jsdelivr.net/npm/reveal.js@3.9.2 \
+    presentation.adoc
 
-. If you did the optional step of having a local reveal.js clone you can
-convert AsciiDoc source with
+. If you did the optional step of having a local clone of reveal.js, you can convert the AsciiDoc source using:
 
-  $ bundle exec asciidoctor-revealjs CONTENT_FILE.adoc
+  $ bundle exec asciidoctor-revealjs presentation.adoc
 
-TIP: If you are using https://pages.github.com/[GitHub Pages], plan ahead by keeping your source files on `master` branch and all output files on the `gh-pages` branch.
+TIP: If you're using {url-gh-pages}[GitHub Pages^], plan ahead by keeping your source files on the default branch and all output files on the `gh-pages` branch.
 
 == Features unique to the Ruby CLI
 
@@ -73,8 +77,11 @@ This can help you achieve even more concise AsciiDoc syntax and integration with
 
 To use it, add the following dependencies to your `Gemfile`:
 
-  gem 'tilt', '~>2.0'
-  gem 'slim', '~>4.0'
+[source,ruby]
+----
+gem 'tilt', '~>2.0'
+gem 'slim', '~>4.0'
+----
 
 Then install the dependencies with:
 
@@ -82,9 +89,9 @@ Then install the dependencies with:
 
 The feature is activated with the `--template-dir` or `-T` option:
 
-  $ bundle exec asciidoctor-revealjs -T templates/ CONTENT_FILE.adoc
+  $ bundle exec asciidoctor-revealjs -T templates presentation.adoc
 
 Any individual template file not provided in the directory specified on the command-line will fall back to the template provided by your version of Asciidoctor reveal.js.
-Refer to our https://github.com/asciidoctor/asciidoctor-reveal.js/tree/master/templates[templates] for inspiration.
+Refer to our {url-project-templates}[templates^] for inspiration.
 
 This feature hasn't been ported to the JavaScript CLI (and API) or the standalone executables.


### PR DESCRIPTION
* make prerequisites reflect current state of Ruby
* use callout to add note about gem command in Gemfile
* use bundle config to set Bundle install path
* add call to bundle
* remove unnecessary --binstubs option when calling Bundler
* use presentation.adoc as the sample presentation file name
* fix some inconsistencies with the AsciiDoc syntax