### PR TITLE
resolves #473 adds extra documentation on document structure and header

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -13,6 +13,7 @@ asciidoc:
     url-project-examples: 'https://github.com/asciidoctor/asciidoctor-reveal.js/tree/master/examples'
     url-project-templates: 'https://github.com/asciidoctor/asciidoctor-reveal.js/tree/master/templates'
     url-asciidoctor: 'https://github.com/asciidoctor/asciidoctor'
+    url-asciidoctor-docs: 'https://docs.asciidoctor.org/asciidoc/latest'
     url-asciidoctorjs: 'https://github.com/asciidoctor/asciidoctor.js'
     url-revealjs-home: 'https://revealjs.com'
     url-revealjs-gh: 'https://github.com/hakimel/reveal.js/blob/v3.9'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -13,7 +13,6 @@ asciidoc:
     url-project-examples: 'https://github.com/asciidoctor/asciidoctor-reveal.js/tree/master/examples'
     url-project-templates: 'https://github.com/asciidoctor/asciidoctor-reveal.js/tree/master/templates'
     url-asciidoctor: 'https://github.com/asciidoctor/asciidoctor'
-    url-asciidoctor-docs: 'https://docs.asciidoctor.org/asciidoc/latest'
     url-asciidoctorjs: 'https://github.com/asciidoctor/asciidoctor.js'
     url-revealjs-home: 'https://revealjs.com'
     url-revealjs-gh: 'https://github.com/hakimel/reveal.js/blob/v3.9'

--- a/docs/modules/converter/pages/features.adoc
+++ b/docs/modules/converter/pages/features.adoc
@@ -29,6 +29,11 @@ A Great Story
 In previous snippet we are creating a slide titled Slide One with bullets and another one titled Slide Two with centered text (reveal.js`' default behavior) with link:{url-revealjs-doc}#speaker-notes[speaker notes].
 Other syntax exists to create speaker notes, see `examples/speaker-notes.adoc`.
 
+IMPORTANT: In order to generate a proper presentation, the source file _must_ contain a proper AsciiDoc document structure.
+This is especially important when configuring how AsciiDoctor-revealjs should convert the document.
+The document properties must be set on the title slide for them to work. 
+See xref:syntax/title.adoc[] for more information.
+
 Starting with reveal.js 3.5 speaker notes supports configurable layouts:
 image:https://cloud.githubusercontent.com/assets/629429/21808439/b941eb52-d743-11e6-9936-44ef80c60580.gif[]
 

--- a/docs/modules/converter/pages/features.adoc
+++ b/docs/modules/converter/pages/features.adoc
@@ -30,7 +30,7 @@ In previous snippet we are creating a slide titled Slide One with bullets and an
 Other syntax exists to create speaker notes, see `examples/speaker-notes.adoc`.
 
 IMPORTANT: In order to generate a proper presentation, the source file _must_ contain a proper AsciiDoc document structure.
-This is especially important when configuring how AsciiDoctor-revealjs should convert the document.
+This is especially important when configuring how Asciidoctor reveal.js should convert the document.
 The document properties must be set on the title slide for them to work. 
 See xref:syntax/title.adoc[] for more information.
 

--- a/docs/modules/converter/pages/syntax/title.adoc
+++ b/docs/modules/converter/pages/syntax/title.adoc
@@ -1,8 +1,7 @@
 = Title Slide
-:navtitle: Title Slide
 
-The title slide is where customization for the generated presentation can be configured via AsciiDoc document attributes.
-These are the global variables assigned at the top of a document under the lead title that look like this: `:name: value`.
+The title slide is where customization for the generated presentation can be configured via AsciiDoc xref:asciidoc:attributes:document-attributes.adoc[document attributes].
+These are the document-scope variables assigned at the top of a document, as part of the document header as xref:asciidoc:attributes:attribute-entries.adoc[attribute entries].
 
 [source,asciidoc]
 ----
@@ -17,8 +16,7 @@ These are the global variables assigned at the top of a document under the lead 
 * World
 ----
 
-In AsciiDoc terms, the first line is the Document Title and the variable definitions following it are considered to be the Document Header.
-See link:{url-asciidoctor-docs}/document/header/[documentation on AsciiDoc Document Header].
+In AsciiDoc terms, the first line is the document title and the variable definitions following it are part of the xref:asciidoc:document:header.adoc[document header].
 
 Note that starting your document with a section title means AsciiDoc interprets your Document Header to be empty.
 Any variables set will not be picked up by the converter and will not influence the resulting presentation.
@@ -27,10 +25,15 @@ The next example shows this mistake:
 [source,asciidoc]
 ----
 == This is not a document title
-// These settings are not interpreted as Document Attributes and have no effect
+// These settings are not interpreted as Document Attributes and will not be accessible to
+// the asciidoctor-revealjs converter.
 :revealjs_theme: sky
 :source-highlighter: highlight.js
 ----
+
+NOTE: Even if you start a document with a level-1 section, you can still have a document header.
+The variables then need to be defined _above_ the section header. Another way to think of this is
+having a document header without a document title.
 
 == Customizing The Title Slide
 
@@ -38,7 +41,7 @@ In addition to configuring document wide settings, the Title Slide can also have
 
 This converter supports changing the color, image, video, iframe and transitions of the Title Slide.
 
-Read link:{url-revealjs-doc}#slide-backgrounds[the relevant reveal.js documentation] to understand what attributes can be set.
+Read {url-revealjs-doc}#slide-backgrounds[the reveal.js documentation] to understand what attributes can be set.
 Keep in mind that for a Title Slide you must replace `data-` with `title-slide-` in the name of the attribute.
 
 See link:{url-project-examples}/title-slide-image.adoc[title-slide-image.adoc] for an example on using these attributes.

--- a/docs/modules/converter/pages/syntax/title.adoc
+++ b/docs/modules/converter/pages/syntax/title.adoc
@@ -18,7 +18,8 @@ These are the document-scope variables assigned at the top of a document, as par
 
 In AsciiDoc terms, the first line is the document title and the variable definitions following it are part of the xref:asciidoc:document:header.adoc[document header].
 
-NOTE: Starting your document with a section title means AsciiDoc interprets your document header to be empty.
+NOTE: Starting your document with a section title means AsciiDoc interprets your document header as empty.
+
 Any variables set will not be picked up by the converter and will not influence the resulting presentation.
 The next example shows this mistake:
 
@@ -37,12 +38,12 @@ Another way to think of this is having a document header without a document titl
 
 == Customizing the Title Slide
 
-In addition to configuring document wide settings, the title slide can also have specialized visual customization that is only applied to the title slide.
+In addition to configuring document-wide settings, the title slide can also define visual customization that is only applied to the title slide.
 
 This converter supports changing the color, image, video, iframe and transitions of the title slide.
 
 Read {url-revealjs-doc}#slide-backgrounds[the reveal.js documentation] to understand what attributes can be set.
-Keep in mind that for a title slide you must replace `data-` with `title-slide-` in the name of the attribute.
+Keep in mind that for a title slide, you must replace `data-` with `title-slide-` in the name of the attribute.
 
 See link:{url-project-examples}/title-slide-image.adoc[title-slide-image.adoc] for an example of using these attributes.
 

--- a/docs/modules/converter/pages/syntax/title.adoc
+++ b/docs/modules/converter/pages/syntax/title.adoc
@@ -18,32 +18,32 @@ These are the document-scope variables assigned at the top of a document, as par
 
 In AsciiDoc terms, the first line is the document title and the variable definitions following it are part of the xref:asciidoc:document:header.adoc[document header].
 
-Note that starting your document with a section title means AsciiDoc interprets your Document Header to be empty.
+Note that starting your document with a section title means AsciiDoc interprets your document header to be empty.
 Any variables set will not be picked up by the converter and will not influence the resulting presentation.
 The next example shows this mistake:
 
 [source,asciidoc]
 ----
 == This is not a document title
-// These settings are not interpreted as Document Attributes and will not be accessible to
+// These settings are not interpreted as document attributes and will not be accessible to
 // the asciidoctor-revealjs converter.
 :revealjs_theme: sky
 :source-highlighter: highlight.js
 ----
 
 NOTE: Even if you start a document with a level-1 section, you can still have a document header.
-The variables then need to be defined _above_ the section header. Another way to think of this is
-having a document header without a document title.
+The variables then need to be defined _above_ the section header.
+Another way to think of this is having a document header without a document title.
 
-== Customizing The Title Slide
+== Customizing the Title Slide
 
-In addition to configuring document wide settings, the Title Slide can also have specialized visual customization that is only applied to the Title Slide.
+In addition to configuring document wide settings, the title slide can also have specialized visual customization that is only applied to the title slide.
 
-This converter supports changing the color, image, video, iframe and transitions of the Title Slide.
+This converter supports changing the color, image, video, iframe and transitions of the title slide.
 
 Read {url-revealjs-doc}#slide-backgrounds[the reveal.js documentation] to understand what attributes can be set.
-Keep in mind that for a Title Slide you must replace `data-` with `title-slide-` in the name of the attribute.
+Keep in mind that for a title slide you must replace `data-` with `title-slide-` in the name of the attribute.
 
-See link:{url-project-examples}/title-slide-image.adoc[title-slide-image.adoc] for an example on using these attributes.
+See link:{url-project-examples}/title-slide-image.adoc[title-slide-image.adoc] for an example of using these attributes.
 
-The Title Slide also given an special `title` CSS class to help with template customization.
+The title slide also given an special `title` CSS class to help with template customization.

--- a/docs/modules/converter/pages/syntax/title.adoc
+++ b/docs/modules/converter/pages/syntax/title.adoc
@@ -18,7 +18,7 @@ These are the document-scope variables assigned at the top of a document, as par
 
 In AsciiDoc terms, the first line is the document title and the variable definitions following it are part of the xref:asciidoc:document:header.adoc[document header].
 
-Note that starting your document with a section title means AsciiDoc interprets your document header to be empty.
+NOTE: Starting your document with a section title means AsciiDoc interprets your document header to be empty.
 Any variables set will not be picked up by the converter and will not influence the resulting presentation.
 The next example shows this mistake:
 

--- a/docs/modules/converter/pages/syntax/title.adoc
+++ b/docs/modules/converter/pages/syntax/title.adoc
@@ -1,7 +1,7 @@
 = Title Slide
 :navtitle: Title Slide
 
-The Title Slide is where customization for the generated presentation can be configured via AsciiDoc document attributes.
+The title slide is where customization for the generated presentation can be configured via AsciiDoc document attributes.
 These are the global variables assigned at the top of a document under the lead title that look like this: `:name: value`.
 
 [source,asciidoc]

--- a/docs/modules/converter/pages/syntax/title.adoc
+++ b/docs/modules/converter/pages/syntax/title.adoc
@@ -1,16 +1,46 @@
-= Title Slide Customization
+= Title Slide
 :navtitle: Title Slide
 
-The title slide is customized via AsciiDoc attributes.
-These are the global variable assigned at the top of a document under the lead
-title that look like this: `:name: value`.
+The Title Slide is where customization for the generated presentation can be configured via AsciiDoc document attributes.
+These are the global variables assigned at the top of a document under the lead title that look like this: `:name: value`.
 
-This converter supports changing the color, image, video, iframe and
-transitions of the title slide.
+[source,asciidoc]
+----
+= Title Slide
+:revealjs_theme: sky
+:source-highlighter: highlight.js
 
-Read link:{url-revealjs-doc}#slide-backgrounds[the relevant reveal.js documentation] to understand what attributes need to be set.
-Keep in mind that for title slides you must replace `data-` with `title-slide-`.
+== Slide One
 
-See link:{url-project-examples}/title-slide-image.adoc[title-slide-image.adoc].
+* Foo
+* Bar
+* World
+----
 
-The title slide is also added a `title` CSS class to help with template customization.
+In AsciiDoc terms, the first line is the Document Title and the variable definitions following it are considered to be the Document Header.
+See link:{url-asciidoctor-docs}/document/header/[documentation on AsciiDoc Document Header].
+
+Note that starting your document with a section title means AsciiDoc interprets your Document Header to be empty.
+Any variables set will not be picked up by the converter and will not influence the resulting presentation.
+The next example shows this mistake:
+
+[source,asciidoc]
+----
+== This is not a document title
+// These settings are not interpreted as Document Attributes and have no effect
+:revealjs_theme: sky
+:source-highlighter: highlight.js
+----
+
+== Customizing The Title Slide
+
+In addition to configuring document wide settings, the Title Slide can also have specialized visual customization that is only applied to the Title Slide.
+
+This converter supports changing the color, image, video, iframe and transitions of the Title Slide.
+
+Read link:{url-revealjs-doc}#slide-backgrounds[the relevant reveal.js documentation] to understand what attributes can be set.
+Keep in mind that for a Title Slide you must replace `data-` with `title-slide-` in the name of the attribute.
+
+See link:{url-project-examples}/title-slide-image.adoc[title-slide-image.adoc] for an example on using these attributes.
+
+The Title Slide also given an special `title` CSS class to help with template customization.


### PR DESCRIPTION
I've added the suggested extra notes and links. The sample-presentation now has an `IMPORTANT` block pointing out the need for proper document structure. It links to the page about the Title Slide. On the Title Slide page, I've added both a good and a bad example of a Document Header and a link to the AsciiDoc page on the Document Header.

I couldn't find how to generate the site to test if my changes looked good. I installed antora, but I might have a newer version as it complains about incorrect configuration. If someone could tell me how to generate the site to verify if links work, I'll gladly do that before finalizing this PR.

I'm looking forward to your review.