### PR TITLE
#496 - Update Reveal.js version to resolve CVE-2022-0776

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/asciidoctor/asciidoctor-reveal.js",
   "dependencies": {
     "@asciidoctor/cli": "^3.1.0",
-    "reveal.js": "4.1.2"
+    "reveal.js": "4.4.0"
   },
   "devDependencies": {
     "@asciidoctor/core": "^2.2.4",


### PR DESCRIPTION
closes #496 