### PR TITLE
Add header docinfo support

### DIFF
--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -66,6 +66,8 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
     - unless (_docinfo = docinfo :head, '-revealjs.html').empty?
       =_docinfo
   body
+    - unless (docinfo_content = (docinfo :header, '.html')).empty?
+      =docinfo_content
     .reveal
       / Any section element inside of this container is displayed as a slide
       .slides


### PR DESCRIPTION
Head, header and footer reveal.js docinfo, and footer docinfo are already supported. However, header docinfo is not, but may be useful to add a logo for example. It can also confuse users that this is not working like in other AsciiDoc documents (maybe head docinfo should be added as well).