### PR TITLE
Add support for fragments on table rows

### DIFF
--- a/docs/modules/project/pages/hacking.adoc
+++ b/docs/modules/project/pages/hacking.adoc
@@ -147,7 +147,7 @@ Go to `test/doctest` folder and install `reveal.js`:
 
 From the project's root directory:
 
- $ bundle exec rake doctest::generate FORCE=yes
+ $ bundle exec rake doctest:generate FORCE=yes
 
 === Open rendered files
 

--- a/examples/fragments.adoc
+++ b/examples/fragments.adoc
@@ -42,3 +42,13 @@ This is step two:
 
  $ echo 'hello world'
 --
+
+== Fragments on tables
+
+[%rowStep]
+|===
+|Fruit |Color
+
+|Apple |red
+|Banana |yellow
+|===

--- a/examples/fragments.adoc
+++ b/examples/fragments.adoc
@@ -45,7 +45,7 @@ This is step two:
 
 == Fragments on tables
 
-[%rowStep]
+[%rowSteps]
 |===
 |Fruit |Color
 

--- a/templates/table.html.slim
+++ b/templates/table.html.slim
@@ -15,7 +15,7 @@
       / not sure about this one, done when converting to a compilable slim template
       <t#{tblsec}>
         - @rows[tblsec].each do |row|
-          tr class=('fragment' if (tblsec != :head) && ((option? :rowStep) || (has_role? 'rowStep') || (attr? 'rowStep')))
+          tr class=('fragment' if (tblsec != :head) && ((option? :rowSteps) || (has_role? 'rowSteps') || (attr? 'rowSteps')))
             - row.each do |cell|
               / store reference of content in advance to resolve attribute assignments in cells
               - if tblsec == :head

--- a/templates/table.html.slim
+++ b/templates/table.html.slim
@@ -15,7 +15,7 @@
       / not sure about this one, done when converting to a compilable slim template
       <t#{tblsec}>
         - @rows[tblsec].each do |row|
-          tr
+          tr class=('fragment' if (tblsec != :head) && ((option? :rowStep) || (has_role? 'rowStep') || (attr? 'rowStep')))
             - row.each do |cell|
               / store reference of content in advance to resolve attribute assignments in cells
               - if tblsec == :head

--- a/test/doctest/fragments.html
+++ b/test/doctest/fragments.html
@@ -86,6 +86,41 @@
       </div>
     </div>
   </section>
+  <section id="_fragments_on_tables">
+    <h2>Fragments on tables</h2>
+    <div class="slide-content">
+      <table class="tableblock frame-all grid-all" style="width: 100%;">
+        <colgroup>
+          <col style="width: 50%;">
+          <col style="width: 50%;">
+        </colgroup>
+        <thead>
+          <tr>
+            <th class="tableblock halign-left valign-top">Fruit</th>
+            <th class="tableblock halign-left valign-top">Color</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="fragment">
+            <td class="tableblock halign-left valign-top">
+              <p class="tableblock">Apple</p>
+            </td>
+            <td class="tableblock halign-left valign-top">
+              <p class="tableblock">red</p>
+            </td>
+          </tr>
+          <tr class="fragment">
+            <td class="tableblock halign-left valign-top">
+              <p class="tableblock">Banana</p>
+            </td>
+            <td class="tableblock halign-left valign-top">
+              <p class="tableblock">yellow</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 </div>
 <script src="reveal.js/dist/reveal.js"></script>
 <script>


### PR DESCRIPTION
This change will add stepping through table rows via option, role or attribute `rowSteps` on the table block.