### PR TITLE
Automate release process via GitHub Actions

### DIFF
--- a/.github/workflows/build-upstream.yml
+++ b/.github/workflows/build-upstream.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '16'
       - name: Configure Nokogiri installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         ruby: ['2.7', '3.0']
         include:
           - os: ubuntu-22.04
-            ruby: truffleruby-22.3.1
+            ruby: truffleruby
           - os: ubuntu-22.04
             ruby: jruby-9.4.14.0
           - os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         ruby: ['2.7', '3.0']
         include:
           - os: ubuntu-22.04
-            ruby: truffleruby
+            ruby: truffleruby-34.0.1
           - os: ubuntu-22.04
             ruby: jruby-9.4.14.0
           - os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - os: ubuntu-22.04
             ruby: truffleruby-22.3.1
           - os: ubuntu-22.04
-            ruby: jruby-9.4.2.0
+            ruby: jruby-9.4.14.0
           - os: macos-latest
             ruby: '2.7'
           - os: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       JRUBY_OPTS: '-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -66,9 +66,9 @@ jobs:
             node-version: '16'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Ruby

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,33 @@
+name: Begin next development version
+
+# Run this manually after a final release (not after a pre-release) to bump the
+# minor version and switch master back to a -dev version, e.g. 5.3.0 -> 5.4.0-dev.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  next:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+      # bumps the minor version to the next -dev in package.json, version.rb and
+      # docs/antora.yml, drops the generated converter.rb from the index and commits
+      - name: Begin next development version
+        run: npm run release:next
+      - name: Push
+        run: git push origin master

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: master
           fetch-depth: 0
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16
       - name: Configure Git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: master
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
         with:
           ruby-version: '2.7'
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16
       - name: Configure Nokogiri installation (Linux)
@@ -62,7 +62,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: refs/tags/v${{ inputs.version }}
       - uses: ruby/setup-ruby@v1
@@ -92,10 +92,10 @@ jobs:
     needs: publish_ruby
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: refs/tags/v${{ inputs.version }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,70 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v2.1.3
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 5.3.0 or 5.3.0-beta.1)'
+        required: true
+        type: string
+
+# Allow the prepare job to push the release commits and tag, and the publish
+# job to create the GitHub release.
+permissions:
+  contents: write
 
 jobs:
-  build_ruby:
+  # Bump the version, build, run the tests and, only if everything is green,
+  # commit + tag and push upstream. The tag stays local until the tests pass,
+  # so a failing build never leaks a release tag.
+  prepare:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-depth: 0
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Configure Nokogiri installation (Linux)
-        if: matrix.os == 'ubuntu-latest'
         run: |
           bundle config --local build__nokogiri --use-system-libraries
           sudo apt-get install libxslt1-dev
       - name: Install dependencies
-        run: bundle --jobs 3 --retry 3
-      - name: Build
-        run: bundle exec rake build
+        run: |
+          bundle --jobs 3 --retry 3
+          npm ci
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+      # bumps package.json + version.rb, builds, then commits and tags locally
+      - name: Prepare release
+        run: npm run release:prepare ${{ inputs.version }}
       - name: Run tests
-        run: bundle exec rake test
-      - name: Run examples:convert
-        run: bundle exec rake examples:convert
+        run: |
+          bundle exec rake test
+          bundle exec rake examples:convert
+          bundle exec rake build:js
+          npm test
+      # only reached when the tests above succeed
+      - name: Push release commits and tag
+        run: git push origin master --tags
+
   publish_ruby:
-    needs: build_ruby
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: refs/tags/v${{ inputs.version }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
@@ -51,7 +83,7 @@ jobs:
       - name: Build gem
         run: |
           gem build asciidoctor-revealjs.gemspec
-      # can't use "${GITHUB_REF#refs/tags/v}" because the actual RubyGem version can be slightly different on prerelease
+      # the actual RubyGem version can be slightly different on prerelease, hence the wildcard
       # see: https://guides.rubygems.org/patterns/#prerelease-gems
       - name: Publish to rubygems.org
         run: |
@@ -61,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: refs/tags/v${{ inputs.version }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -85,45 +119,17 @@ jobs:
         run: |
           npm publish
           npm run package
-          npm run release:description ${GITHUB_REF#refs/tags/v}
-      # create the GitHub release
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1.1.4
+          npm run release:description ${{ inputs.version }}
+      # create the GitHub release and upload the platform binaries
+      # --prerelease is added automatically for versions carrying a pre-release suffix (e.g. 5.3.0-beta.1)
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          body_path: dist/changelog.md
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-      # upload binaries
-      - name: Upload Linux binary
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/reveal-linux
-          asset_name: asciidoctor-revealjs-linux
-          asset_content_type: application/octet-stream
-      - name: Upload macOS binary
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/reveal-macos
-          asset_name: asciidoctor-revealjs-macos
-          asset_content_type: application/octet-stream
-      - name: Upload Windows binary
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/reveal-win.exe
-          asset_name: asciidoctor-revealjs-win.exe
-          asset_content_type: application/octet-stream
-
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "v${{ inputs.version }}" \
+            --notes-file dist/changelog.md \
+            ${{ contains(inputs.version, '-') && '--prerelease' || '' }} \
+            "dist/reveal-linux#asciidoctor-revealjs-linux" \
+            "dist/reveal-macos#asciidoctor-revealjs-macos" \
+            "dist/reveal-win.exe#asciidoctor-revealjs-win.exe"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a detailed view of what has changed, refer to the [commit history](https://g
   * Replace the archived `actions/create-release` and `actions/upload-release-asset` actions with the GitHub CLI
   * Bump `actions/checkout` and `actions/setup-node` to their latest versions
   * Fix `NoSuchMethodError` (`RubyFixnum.newFixnum`) in the JRuby test job by bumping JRuby from 9.4.2.0 to 9.4.14.0
+  * Fix the TruffleRuby test job (psych 5.4.0 native build failure) by using the latest stable TruffleRuby instead of 22.3.1
   * Upgrade `asciidoctor-doctest` to the released 2.0.0 (and relax the `minitest` constraint to `~> 5.25`)
 
 ## 5.2.0 (2024-02-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For a detailed view of what has changed, refer to the [commit history](https://g
   * Replace the archived `actions/create-release` and `actions/upload-release-asset` actions with the GitHub CLI
   * Bump `actions/checkout` and `actions/setup-node` to their latest versions
   * Fix `NoSuchMethodError` (`RubyFixnum.newFixnum`) in the JRuby test job by bumping JRuby from 9.4.2.0 to 9.4.14.0
-  * Fix the TruffleRuby test job (psych 5.4.0 native build failure) by using the latest stable TruffleRuby instead of 22.3.1
+  * Fix the TruffleRuby test job (psych 5.4.0 native build failure) by bumping TruffleRuby from 22.3.1 to 34.0.1
   * Upgrade `asciidoctor-doctest` to the released 2.0.0 (and relax the `minitest` constraint to `~> 5.25`)
 
 ## 5.2.0 (2024-02-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 
 ## master (unreleased)
 
-## 5.2 (2024-02-12)
+### Build
+
+  * Automate the release process via GitHub Actions, triggered from the Actions UI with a version input
+  * Add a workflow to begin the next development version after a final release
+  * Mark GitHub releases as pre-releases automatically for pre-release versions
+  * Replace the archived `actions/create-release` and `actions/upload-release-asset` actions with the GitHub CLI
+  * Bump `actions/checkout` and `actions/setup-node` to their latest versions
+
+## 5.2.0 (2024-02-12)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 
 ## master (unreleased)
 
+### Bug Fixes
+
+  * Fix `NoSuchMethodError` (`RubyFixnum.newFixnum`) on JRuby 9.4 by upgrading `asciidoctor-doctest` to 2.0.0 (pulling Nokogiri 1.14 instead of 1.13)
+
 ### Build
 
   * Automate the release process via GitHub Actions, triggered from the Actions UI with a version input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 
 ## master (unreleased)
 
-### Bug Fixes
-
-  * Fix `NoSuchMethodError` (`RubyFixnum.newFixnum`) on JRuby 9.4 by upgrading `asciidoctor-doctest` to 2.0.0 (pulling Nokogiri 1.14 instead of 1.13)
-
 ### Build
 
   * Automate the release process via GitHub Actions, triggered from the Actions UI with a version input
@@ -16,6 +12,8 @@ For a detailed view of what has changed, refer to the [commit history](https://g
   * Mark GitHub releases as pre-releases automatically for pre-release versions
   * Replace the archived `actions/create-release` and `actions/upload-release-asset` actions with the GitHub CLI
   * Bump `actions/checkout` and `actions/setup-node` to their latest versions
+  * Fix `NoSuchMethodError` (`RubyFixnum.newFixnum`) in the JRuby test job by bumping JRuby from 9.4.2.0 to 9.4.14.0
+  * Upgrade `asciidoctor-doctest` to the released 2.0.0 (and relax the `minitest` constraint to `~> 5.25`)
 
 ## 5.2.0 (2024-02-12)
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ gemspec
 group :development do
   # Asciidoctor.js 3.0.0 requires Opal 1.7.3
   gem 'opal', '1.7.3'
-  # Asciidoctor Doctest based on Nokogiri 1.13
-  gem 'asciidoctor-doctest', git: 'https://github.com/ggrossetie/asciidoctor-doctest.git', :ref => 'c2cba5240'
+  gem 'asciidoctor-doctest', '2.0.0'
 end

--- a/asciidoctor-revealjs.gemspec
+++ b/asciidoctor-revealjs.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0.0'
   # Overriden in Gemfile
   #s.add_development_dependency 'asciidoctor-doctest', '= 2.0.0.beta.7'
-  s.add_development_dependency 'minitest', [ '~> 5.24.0', '< 5.25']
+  s.add_development_dependency 'minitest', '~> 5.25'
   if RUBY_ENGINE != 'jruby'
     s.add_development_dependency 'pry', '~> 0.12.0'
     s.add_development_dependency 'irb'

--- a/docs/modules/project/pages/hacking.adoc
+++ b/docs/modules/project/pages/hacking.adoc
@@ -340,21 +340,30 @@ You can get the list of all contributors using `git` (don't forget to replace `%
 . Make sure that the highlight plugin code embed in _lib/asciidoctor-revealjs/highlightjs.rb_ is up-to-date with the version of reveal.js
 . Do we need to do anything regarding our Opal dependency and Asciidoctor.js?
 See <<node-binary-compatibility,our section on the topic>>.
-. Run the following command to prepare the release (don't forget to replace `%version%` with an actual version):
-
- $ npm run release:prepare %version%
-
-. Push your changes (including the tag):
-
- $ git push origin master --tags
+. Make sure the changelog entry for the version you are about to release is committed and pushed to `master`.
 
 === Release
 
-The release process is automated and relies on GitHub Actions.
+The release is fully automated and triggered from GitHub Actions.
 We are using personal tokens to publish to rubygems.org and npmjs.com.
 
 The `RUBYGEMS_API_KEY` and `NPM_TOKEN` secrets are configured on GitHub.
 See the `.github/workflows/release.yml` file for details.
+
+To trigger a release:
+
+. Go to the https://github.com/asciidoctor/asciidoctor-reveal.js/actions/workflows/release.yml[Release workflow] on GitHub Actions.
+. Click *Run workflow*, keep the `master` branch selected, and enter the version to release (e.g., `5.3.0` or `5.3.0-beta.1`).
+. Click *Run workflow*.
+
+The workflow bumps the version in _package.json_ and _lib/asciidoctor-revealjs/version.rb_, builds the project and runs the tests.
+Only if the tests pass does it commit, tag (`v%version%`) and push to `master`, then publish to rubygems.org and npmjs.com and create the GitHub release with the platform binaries.
+
+[NOTE]
+====
+The `master` branch must allow the `github-actions[bot]` to push the release commits and tag.
+If branch protection rules reject the push, the release will fail at the *Push release commits and tag* step.
+====
 
 Once the https://github.com/asciidoctor/asciidoctor-reveal.js/actions?query=workflow%3Arelease[release workflow]
 has been completed:
@@ -375,9 +384,12 @@ also amend `WhenBackendIsRevealJs.java` in both `tests` and `itests` folders and
 
 === Prepare next version
 
-This step is optional and should only be done if needed.
+This step is optional and should only be done after a *final* release (not after a pre-release such as `5.3.0-beta.1`).
 
-. Run the following command and follow the instructions:
+Trigger the https://github.com/asciidoctor/asciidoctor-reveal.js/actions/workflows/post-release.yml[Begin next development version workflow] from GitHub Actions.
+It bumps the minor version to the next `-dev` version (e.g., `5.3.0` -> `5.4.0-dev`) in _package.json_, _lib/asciidoctor-revealjs/version.rb_ and _docs/antora.yml_, then commits and pushes to `master`.
+
+Alternatively, you can run it locally and follow the printed instructions:
 
  $ npm run release:next
 


### PR DESCRIPTION
Trigger releases from the GitHub Actions UI instead of running the
release scripts locally and pushing a tag.

- release.yml: switch from a tag push trigger to workflow_dispatch with a
  required `version` input. A `prepare` job bumps the version, builds and
  runs the tests, then commits, tags and pushes only when the tests pass,
  before the existing publish jobs run against the new tag.
- Mark the GitHub release as a pre-release automatically when the version
  carries a pre-release suffix (e.g. 5.3.0-beta.1).
- Replace the archived actions/create-release and
  actions/upload-release-asset actions with the gh CLI.
- post-release.yml: new workflow_dispatch workflow to begin the next -dev
  development version after a final release.
- Document the new GitHub-triggered release process.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>