### PR TITLE
chore: update asciidoctor to 4.0.0-alpha.6 and drop fixed workarounds

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -1,7 +1,7 @@
 # Native JavaScript reveal.js converter
 
 A native JavaScript implementation of the Asciidoctor reveal.js converter, built
-on the **Asciidoctor.js 4.0** converter API (`@asciidoctor/core@>=4.0.0-alpha.5`).
+on the **Asciidoctor.js 4.0** converter API (`asciidoctor@>=4.0.0-alpha.6`).
 
 Asciidoctor.js 4.0 is a native JavaScript rewrite of Asciidoctor (no longer an
 Opal transpilation), so this converter is a direct, idiomatic port of the Ruby
@@ -10,7 +10,7 @@ converter in `../lib/asciidoctor_revealjs/` rather than transpiled output.
 ## Requirements
 
 - **Node.js >= 18** (the Asciidoctor.js 4.0 ESM build uses import attributes).
-- `@asciidoctor/core@>=4.0.0-alpha.5` (peer dependency).
+- `asciidoctor@>=4.0.0-alpha.6` (peer dependency).
 
 This code ships as part of the `@asciidoctor/reveal.js` package: the repository's
 root `package.json` declares `"type": "module"` and points `main` at
@@ -19,7 +19,7 @@ root `package.json` declares `"type": "module"` and points `main` at
 ## Usage
 
 ```js
-import { convert } from '@asciidoctor/core'
+import { convert } from 'asciidoctor'
 import { register } from '@asciidoctor/reveal.js'
 
 register() // registers the `revealjs` / `reveal.js` backends and the highlight.js adapter
@@ -48,11 +48,6 @@ cat slides.adoc | node js/bin/asciidoctor-revealjs -    # read from stdin
 Run `--help` for the full option list. The standalone `@asciidoctor/cli` package
 is **not** used — it is CommonJS and still calls the removed `asciidoctor()`
 3.x factory; the `asciidoctor` meta package bundles core 4.0 + an ESM CLI instead.
-
-> Note: `import … from 'asciidoctor'` (the package main) is broken with
-> `@asciidoctor/core@4.0.0-alpha.5` (it re-exports a non-existent `default`), so
-> the converter still imports from `@asciidoctor/core` (resolved transitively via
-> `asciidoctor`); only the bin imports the working `asciidoctor/cli` subpath.
 
 ## Layout
 
@@ -87,8 +82,6 @@ presentations in `../examples`, 65 are identical. The remaining differences are
 - Convert handlers are **async** (`await node.content()`); per-slide footnote
   state must be mutated in document order, so vertical slides/blocks are
   converted sequentially (never with `Promise.all`).
-- `node.findBy()` throws on `List` nodes when the tree contains a description
-  list, so a local `safeFindBy` traversal is used instead.
 
 ## Test
 

--- a/js/src/converter.js
+++ b/js/src/converter.js
@@ -12,7 +12,7 @@
 //   - node.option? → node.hasOption() ; node.has_role? → node.hasRole()
 //   - Ruby symbol keys → plain string keys.
 
-import { ConverterBase, Html5Converter, SafeMode } from '@asciidoctor/core'
+import { ConverterBase, Html5Converter, SafeMode } from 'asciidoctor'
 import { extname } from 'node:path'
 import { COMPATIBILITY } from './stylesheet.js'
 import { script as revealJsScript, stretchNestedElements } from './reveal-js-options.js'
@@ -152,27 +152,6 @@ function inlineTextContainer (node, content) {
     return `<span${attributes({ id: node.getId(), class: classes, ...da })}>${content}</span>`
   }
   return content
-}
-
-// Depth-first search for descendant nodes of the given `context` matching the
-// optional `filter`, including `node` itself (like Ruby AbstractNode#find_by).
-//
-// Implemented manually because Asciidoctor.js 4.0-alpha's findBy throws
-// ("Receiver must be an instance of class AbstractBlock") when the traversed
-// tree contains a description list.
-function safeFindBy (node, context, filter = null, acc = []) {
-  if (typeof node.getContext === 'function' && node.getContext() === context && (!filter || filter(node))) {
-    acc.push(node)
-  }
-  if (typeof node.getItems === 'function') {
-    for (const item of node.getItems()) {
-      const subs = Array.isArray(item) ? item.flat(Infinity) : [item]
-      for (const sub of subs) if (sub && typeof sub.getContext === 'function') safeFindBy(sub, context, filter, acc)
-    }
-  } else if (typeof node.getBlocks === 'function') {
-    for (const child of node.getBlocks()) if (child && typeof child.getContext === 'function') safeFindBy(child, context, filter, acc)
-  }
-  return acc
 }
 
 // Copied from asciidoctor html5 converter (private method).
@@ -340,7 +319,7 @@ export default class RevealJsConverter extends ConverterBase {
     } else {
       buf += `<h1>${node.getHeader().title}</h1>`
     }
-    const preamble = safeFindBy(node.getDocument(), 'preamble')
+    const preamble = node.getDocument().findBy({ context: 'preamble' })
     if (preamble && preamble.length > 0) {
       buf += `<div class="preamble">${await preamble[preamble.length - 1].content()}</div>`
     }
@@ -355,7 +334,7 @@ export default class RevealJsConverter extends ConverterBase {
     const titleless = title === '!'
     const hideTitle = titleless || node.hasOption('notitle') || node.hasOption('conceal')
 
-    const verticalSlides = safeFindBy(node, 'section', (section) => section.getLevel() === 2)
+    const verticalSlides = node.findBy({ context: 'section' }, (section) => section.getLevel() === 2)
 
     // extracting block image attributes to find an image to use as a background_image attribute
     let dataBackgroundImage = null
@@ -375,7 +354,7 @@ export default class RevealJsConverter extends ConverterBase {
       } else if (ctx === 'section') {
         // skip nested sections
       } else {
-        safeFindBy(block, 'image', (image) => ['background', 'canvas'].includes(image.getAttribute(1)), sectionImages)
+        sectionImages.push(...block.findBy({ context: 'image' }, (image) => ['background', 'canvas'].includes(image.getAttribute(1))))
       }
     }
     const bgImage = sectionImages[0]

--- a/js/src/converter.js
+++ b/js/src/converter.js
@@ -424,9 +424,7 @@ export default class RevealJsConverter extends ConverterBase {
         if (content !== '') inner += `<div class="slide-content">${content}</div>`
       }
       inner += footnotes()
-      const buf = `<section${attrs}>${inner}</section>`
-      Footnotes.clearSlideFootnotes()
-      return buf
+      return `<section${attrs}>${inner}</section>`
     }
 
     // RENDERING

--- a/js/src/footnotes.js
+++ b/js/src/footnotes.js
@@ -1,57 +1,70 @@
 // Port of the Footnotes module in lib/asciidoctor_revealjs/converter.rb
 //
-// Display footnotes per slide. Footnotes declared on a section title are
-// processed during parsing/substitution, so they are stored separately to be
-// displayed on the right slide/section.
+// Display footnotes per slide. Footnotes are numbered from 1 again on every
+// slide; a footnote referenced more than once on the same slide keeps its
+// number. Footnotes are bucketed by the section (slide) that contains them,
+// keyed by node identity, so the result does not depend on the order in which
+// Asciidoctor.js substitutes them.
+//
+// This independence matters with the Asciidoctor.js 4.0 core: footnotes inside
+// list items (and on section titles) are substituted eagerly, before any slide
+// is rendered, and the core's `index` attribute is not a reliable document-wide
+// identifier. Bucketing by the enclosing section and de-duplicating reused
+// footnotes by their id avoids relying on either.
 //
 // Stored footnotes are plain objects { index, id, text } (the Ruby code uses
 // Asciidoctor::Document::Footnote, but only index/text are read back).
 
 import { Inline } from 'asciidoctor'
 
-// footnote index (initial) -> stored footnote { index, id, text }
-let slideFootnotesByIndex = new Map()
-// section node (by identity) -> array of footnotes { index, id, text }
-const sectionFootnotes = new Map()
+// section node (by identity) -> array of footnotes { index, id, text } declared
+// on the section title.
+const titleFootnotes = new Map()
+// section node (by identity) -> array of footnotes { index, id, text } declared
+// in the section body.
+const bodyFootnotes = new Map()
 
 function isSection (node) {
   return node != null && typeof node.getContext === 'function' && node.getContext() === 'section'
 }
 
+// Walk up to the section (slide) that contains the footnote.
+function enclosingSection (node) {
+  let parent = node.getParent()
+  while (parent != null && !isSection(parent)) parent = parent.getParent()
+  return parent
+}
+
 export function slideFootnote (footnote) {
   const footnoteParent = footnote.getParent()
-  let inlineFootnote
-  // footnotes declared on the section title are processed during the
-  // parsing/substitution; store them to display them on the right slide/section.
+  // Footnotes declared on the section title are stored against that section so
+  // they show up on its slide.
   if (isSection(footnoteParent)) {
-    const sectionFn = sectionFootnotes.get(footnoteParent) || []
-    const footnoteIndex = sectionFn.length + 1
-    const attributes = { ...footnote.getAttributes(), index: footnoteIndex }
-    inlineFootnote = new Inline(footnoteParent, footnote.getContext(), footnote.getText(), { attributes })
-    sectionFn.push({ index: inlineFootnote.getAttribute('index'), id: inlineFootnote.getId(), text: inlineFootnote.getText() })
-    sectionFootnotes.set(footnoteParent, sectionFn)
-  } else {
-    let parent = footnote.getParent()
-    while (parent != null && !isSection(parent)) parent = parent.getParent()
-    // check if there is any footnote attached on the section title
-    const sectionFn = parent == null ? [] : (sectionFootnotes.get(parent) || [])
-    const initialIndex = footnote.getAttribute('index')
-    // reset the footnote numbering to 1 on each slide; reuse the same index when
-    // a footnote is used more than once.
-    const existingFootnote = slideFootnotesByIndex.get(initialIndex)
-    const slideIndex = existingFootnote ? existingFootnote.index : slideFootnotesByIndex.size + sectionFn.length + 1
-    const attributes = { ...footnote.getAttributes(), index: slideIndex }
-    inlineFootnote = new Inline(footnoteParent, footnote.getContext(), footnote.getText(), { attributes })
-    slideFootnotesByIndex.set(initialIndex, { index: inlineFootnote.getAttribute('index'), id: inlineFootnote.getId(), text: inlineFootnote.getText() })
+    const sectionFn = titleFootnotes.get(footnoteParent) || []
+    const index = sectionFn.length + 1
+    const inlineFootnote = new Inline(footnoteParent, footnote.getContext(), footnote.getText(), { attributes: { ...footnote.getAttributes(), index } })
+    sectionFn.push({ index, id: inlineFootnote.getId(), text: inlineFootnote.getText() })
+    titleFootnotes.set(footnoteParent, sectionFn)
+    return inlineFootnote
+  }
+
+  const section = enclosingSection(footnote)
+  const titleFn = section == null ? [] : (titleFootnotes.get(section) || [])
+  const bodyFn = section == null ? [] : (bodyFootnotes.get(section) || [])
+  // A footnote with an id can be referenced again on the same slide; reuse its
+  // number. A definition carries the id on `getId()`, a later reference carries
+  // it on `getTarget()`. Anonymous footnotes (neither) are always distinct.
+  const id = footnote.getId() || footnote.getTarget()
+  const existing = id ? bodyFn.find((fn) => fn.id === id) : null
+  const index = existing ? existing.index : titleFn.length + bodyFn.length + 1
+  const inlineFootnote = new Inline(footnoteParent, footnote.getContext(), footnote.getText(), { attributes: { ...footnote.getAttributes(), index } })
+  if (!existing && section != null) {
+    bodyFn.push({ index, id, text: inlineFootnote.getText() })
+    bodyFootnotes.set(section, bodyFn)
   }
   return inlineFootnote
 }
 
-export function clearSlideFootnotes () {
-  slideFootnotesByIndex = new Map()
-}
-
 export function slideFootnotes (section) {
-  const sectionFn = sectionFootnotes.get(section) || []
-  return [...sectionFn, ...slideFootnotesByIndex.values()]
+  return [...(titleFootnotes.get(section) || []), ...(bodyFootnotes.get(section) || [])]
 }

--- a/js/src/footnotes.js
+++ b/js/src/footnotes.js
@@ -7,7 +7,7 @@
 // Stored footnotes are plain objects { index, id, text } (the Ruby code uses
 // Asciidoctor::Document::Footnote, but only index/text are read back).
 
-import { Inline } from '@asciidoctor/core'
+import { Inline } from 'asciidoctor'
 
 // footnote index (initial) -> stored footnote { index, id, text }
 let slideFootnotesByIndex = new Map()

--- a/js/src/highlightjs.js
+++ b/js/src/highlightjs.js
@@ -5,7 +5,7 @@
 // data-noescape, data-line-numbers, monokai theme, plugin docinfo).
 
 import { readFileSync } from 'node:fs'
-import { SyntaxHighlighterBase } from '@asciidoctor/core'
+import { SyntaxHighlighterBase } from 'asciidoctor'
 
 // REMIND: we cannot use Highlight.js 11+ because unescaped HTML support has been
 // removed (https://github.com/highlightjs/highlight.js/issues/2889). We use

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,13 +1,13 @@
 // Public entry point for the native JavaScript reveal.js converter.
 //
 // Usage:
-//   import asciidoctor from '@asciidoctor/core'
+//   import asciidoctor from 'asciidoctor'
 //   import { register } from '@asciidoctor/reveal.js-converter'
 //   register()
 //   const html = await asciidoctor.convert(input, { backend: 'revealjs', standalone: true })
 
 import { readFileSync } from 'node:fs'
-import { ConverterFactory, SyntaxHighlighter } from '@asciidoctor/core'
+import { ConverterFactory, SyntaxHighlighter } from 'asciidoctor'
 import RevealJsConverter from './converter.js'
 import HighlightJsAdapter from './highlightjs.js'
 

--- a/js/test/converter.test.js
+++ b/js/test/converter.test.js
@@ -3,7 +3,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { convert } from '@asciidoctor/core'
+import { convert } from 'asciidoctor'
 import { register, getVersion } from '../src/index.js'
 
 register()

--- a/js/test/examples.test.js
+++ b/js/test/examples.test.js
@@ -25,7 +25,6 @@ const REVEALJSDIR = 'node_modules/reveal.js'
 // differences are NOT in this converter — they are upstream Asciidoctor.js 4.0-alpha
 // bugs or third-party syntax highlighters provided by Asciidoctor core.
 const SKIP = {
-  'release-4.1.adoc': 'externalized footnote reuse depends on the alpha attribute-substitution timing',
   'source-coderay.adoc': 'third-party syntax highlighter provided by Asciidoctor core (only highlightjs is ported)',
   'source-prettify.adoc': 'third-party syntax highlighter provided by Asciidoctor core (only highlightjs is ported)',
   'source-pygments.adoc': 'third-party syntax highlighter provided by Asciidoctor core (only highlightjs is ported)',

--- a/js/test/examples.test.js
+++ b/js/test/examples.test.js
@@ -14,7 +14,7 @@ import { readdirSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, join, resolve } from 'node:path'
-import { convertFile } from '@asciidoctor/core'
+import { convertFile } from 'asciidoctor'
 import { register } from '../src/index.js'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -25,8 +25,6 @@ const REVEALJSDIR = 'node_modules/reveal.js'
 // differences are NOT in this converter — they are upstream Asciidoctor.js 4.0-alpha
 // bugs or third-party syntax highlighters provided by Asciidoctor core.
 const SKIP = {
-  'admonitions.adoc': "Asciidoctor.js 4.0-alpha drops caption='…' (textlabel becomes the boolean true)",
-  'admonitions-icons.adoc': "Asciidoctor.js 4.0-alpha drops caption='…' (textlabel becomes the boolean true)",
   'release-4.1.adoc': 'externalized footnote reuse depends on the alpha attribute-substitution timing',
   'source-coderay.adoc': 'third-party syntax highlighter provided by Asciidoctor core (only highlightjs is ported)',
   'source-prettify.adoc': 'third-party syntax highlighter provided by Asciidoctor core (only highlightjs is ported)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.3.0-dev",
       "license": "MIT",
       "dependencies": {
-        "asciidoctor": "^4.0.0-alpha.5",
+        "asciidoctor": "^4.0.0-alpha.6",
         "reveal.js": "4.5.0"
       },
       "bin": {
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@asciidoctor/core": {
-      "version": "4.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.5.tgz",
-      "integrity": "sha512-xwR3hyqmXgZ9W0um4GKveKWY9rjLTpkuu2TINC2m9qXb41X15wqYlWcmMRtdqywawYRsf6kaxR47mHqJpVNu4A==",
+      "version": "4.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.6.tgz",
+      "integrity": "sha512-E3ivaaOkY59Zb4oHoPWxFUqkVrngAR7XQGS1FuP/wJNfQ62xL25mW+9bSPkGgB7qBzcuQKHzI5RN1SLIowLSSw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -227,12 +227,12 @@
       }
     },
     "node_modules/asciidoctor": {
-      "version": "4.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.0-alpha.5.tgz",
-      "integrity": "sha512-6mh4HvwG+mxrRbTTsAY8auqGBfo0RucX7eLAcVQlJ9Ez4CZT43oiaCD0TRos/CA7Tri/sIlDmv3u4mdqlaXcAw==",
+      "version": "4.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.0-alpha.6.tgz",
+      "integrity": "sha512-+g1mj5VTTfntHVeWBphOdIONl9zzKIx7RoBtX/pw2A/0tccW+ct1MBOzmcZlHGHZ6JCQ6tpa6yYz+qrRKwizJg==",
       "license": "MIT",
       "dependencies": {
-        "@asciidoctor/core": "4.0.0-alpha.5"
+        "@asciidoctor/core": "4.0.0-alpha.6"
       },
       "bin": {
         "asciidoctor": "bin/asciidoctor",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor-reveal.js",
   "dependencies": {
-    "asciidoctor": "^4.0.0-alpha.5",
+    "asciidoctor": "^4.0.0-alpha.6",
     "reveal.js": "4.5.0"
   },
   "devDependencies": {

--- a/tasks/examples.js
+++ b/tasks/examples.js
@@ -1,7 +1,7 @@
 import { readdirSync } from 'node:fs'
 import path from 'node:path'
 import log from 'bestikk-log'
-import { convertFile } from '@asciidoctor/core'
+import { convertFile } from 'asciidoctor'
 import { register } from '../js/src/index.js'
 
 const examplesDir = 'examples'


### PR DESCRIPTION
alpha.6 fixes the package-main export, findBy on trees containing a
description list, and the admonition caption attribute, so:

- import from 'asciidoctor' instead of the transitive '@asciidoctor/core'
- replace the hand-rolled safeFindBy traversal with native findBy
- unskip the admonitions parity tests (converter output was already correct)

Full parity suite passes (69 ok, 5 skipped for unrelated reasons).