### PR TITLE
chore: upgrade reveal.js to 6.0.1 and clean up release tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 
 ## master (unreleased)
 
+### Enhancements
+
+  * Upgrade to reveal.js 6.0.1
+  * Reimplement the converter in pure Ruby (drop the `asciidoctor-templates-compiler` Slim templates)
+  * Port the converter to native Asciidoctor.js 4.0 (Node 18+, async convert handlers, validated byte-for-byte against the Ruby converter)
+  * Update Asciidoctor to 4.0.0-alpha.6 and drop the workarounds that are no longer needed
+
 ### Build
 
+  * Replace `bestikk-log` with plain `console` logging in the build tasks
+  * Bump the Volta-pinned Node.js to 24.16.0
+  * Improve the Renovate configuration for smaller, scheduled pull requests
   * Automate the release process via GitHub Actions, triggered from the Actions UI with a version input
   * Add a workflow to begin the next development version after a final release
   * Mark GitHub releases as pre-releases automatically for pre-release versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "asciidoctor": "^4.0.0-alpha.6",
-        "reveal.js": "4.5.0"
+        "reveal.js": "6.0.1"
       },
       "bin": {
         "asciidoctor-revealjs": "js/bin/asciidoctor-revealjs"
       },
       "devDependencies": {
-        "bestikk-log": "0.1.0",
         "pkg": "5.8.1"
       },
       "engines": {
@@ -271,15 +270,6 @@
         }
       ]
     },
-    "node_modules/bestikk-log": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bestikk-log/-/bestikk-log-0.1.0.tgz",
-      "integrity": "sha1-asbdy07E776U7gguKJ5Mv2rVTyA=",
-      "dev": true,
-      "dependencies": {
-        "colors": "1.1.2"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -391,15 +381,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -1230,12 +1211,10 @@
       }
     },
     "node_modules/reveal.js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.5.0.tgz",
-      "integrity": "sha512-Lx1hUWhJR7Y7ScQNyGt7TFzxeviDAswK2B0cn9RwbPZogTMRgS8+FTr+/12KNHOegjvWKH0H0EGwBARNDPTgWQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-6.0.1.tgz",
+      "integrity": "sha512-9eacArNIgqO2HGWOK+93gJNn+gvdGDVbSq+i2u3Ja9kjiHps0XNLpgYTZTYjKRH91uXy3clGimeGiw4umHG/tg==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,13 +52,12 @@
   "homepage": "https://github.com/asciidoctor/asciidoctor-reveal.js",
   "dependencies": {
     "asciidoctor": "^4.0.0-alpha.6",
-    "reveal.js": "4.5.0"
+    "reveal.js": "6.0.1"
   },
   "devDependencies": {
-    "bestikk-log": "0.1.0",
     "pkg": "5.8.1"
   },
   "volta": {
-    "node": "20.18.1"
+    "node": "24.16.0"
   }
 }

--- a/tasks/examples.js
+++ b/tasks/examples.js
@@ -1,12 +1,11 @@
 import { readdirSync } from 'node:fs'
 import path from 'node:path'
-import log from 'bestikk-log'
 import { convertFile } from 'asciidoctor'
 import { register } from '../js/src/index.js'
 
 const examplesDir = 'examples'
 
-log.task('examples')
+console.log('examples')
 
 // Register the native reveal.js converter
 register()
@@ -20,9 +19,9 @@ for (const filename of readdirSync(examplesDir)) {
     try {
       // convert handlers are async in Asciidoctor.js 4.0
       await convertFile(path.join(examplesDir, filename), options)
-      log.info(`Successfully converted ${filename}`)
+      console.log(`Successfully converted ${filename}`)
     } catch (err) {
-      log.error(`Error converting ${filename}: ${err}`)
+      console.error(`Error converting ${filename}: ${err}`)
     }
   }
 }

--- a/tasks/release/exec.js
+++ b/tasks/release/exec.js
@@ -1,4 +1,5 @@
 import childProcess from 'node:child_process'
+import process from 'node:process'
 
 export function execSync (command, opts) {
   console.debug(command, opts)

--- a/tasks/release/next.js
+++ b/tasks/release/next.js
@@ -2,6 +2,7 @@ import childProcess from 'node:child_process'
 import path from 'node:path'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import process from 'node:process'
 import { execSync } from './exec.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/tasks/release/prepare.js
+++ b/tasks/release/prepare.js
@@ -2,6 +2,7 @@ import childProcess from 'node:child_process'
 import path from 'node:path'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import process from 'node:process'
 import { execSync } from './exec.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -43,8 +44,8 @@ if (process.env.DRY_RUN) {
 } else {
   writeFileSync(pkgPath, pkgUpdated)
 }
-// update version in lib/asciidoctor-revealjs/version.rb
-const versionRbPath =  path.join(projectRootDirectory, 'lib', 'asciidoctor-revealjs', 'version.rb')
+// update version in lib/asciidoctor_revealjs/version.rb
+const versionRbPath =  path.join(projectRootDirectory, 'lib', 'asciidoctor_revealjs', 'version.rb')
 const versionRbContent = readFileSync(versionRbPath, 'utf8')
 // RubyGems versions must use a slightly different pattern:
 // https://guides.rubygems.org/patterns/#prerelease-gems
@@ -63,9 +64,6 @@ if (process.env.DRY_RUN) {
 } else {
   writeFileSync(versionRbPath, versionRbUpdated)
 }
-execSync('bundle exec rake build', {cwd: projectRootDirectory})
-execSync('git add -f lib/asciidoctor-revealjs/converter.rb', {cwd: projectRootDirectory})
-
 // git commit and tag
 execSync(`git commit -a -m "Prepare ${releaseVersion} release"`, {cwd: projectRootDirectory})
 execSync(`git commit --allow-empty -m "Release ${releaseVersion}"`, {cwd: projectRootDirectory})


### PR DESCRIPTION
- bump reveal.js from 4.5.0 to 6.0.1
- drop bestikk-log in favor of console logging
- bump Volta node to 24.16.0
- import node:process explicitly in release scripts
- fix version.rb path and drop obsolete rake build step
