### PR TITLE
chore: auto-discover release demos when publishing the showcase site

### DIFF
--- a/tasks/index.html
+++ b/tasks/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Asciidoctor reveal.js Examples</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
   </head>
   <body>
   <section class="section">
@@ -21,10 +21,7 @@
     <div class="container">
       <div class="content">
         <ul>
-          <li><a href="./release-5.2.html">Asciidoctor reveal.js 5.2</a></li>
-          <li><a href="./release-5.1.html">Asciidoctor reveal.js 5.1</a></li>
-          <li><a href="./release-4.1.html">Asciidoctor reveal.js 4.1</a></li>
-          <li><a href="./release-4.0.html">Asciidoctor reveal.js 4.0</a></li>
+{{releases}}
         </ul>
       </div>
     </div>

--- a/tasks/publish.rake
+++ b/tasks/publish.rake
@@ -1,21 +1,36 @@
 # frozen_string_literal: true
 
 namespace :examples do
+  # Extra assets (outside the release-*.{html,css} convention) shared by the
+  # release demos and copied verbatim into public/.
+  extra_release_files = ['examples/a11y-dark.css'].freeze
+
   desc 'Build the public/ release showcase site (landing page and release demos)'
   task :publish do
     FileUtils.rm_rf PUBLIC_DIR
     Dir.mkdir PUBLIC_DIR
     Dir.mkdir "#{PUBLIC_DIR}/reveal.js"
-    FileUtils.cp 'tasks/index.html', "#{PUBLIC_DIR}/index.html"
     FileUtils.cp_r 'node_modules/reveal.js/', PUBLIC_DIR.to_s
     FileUtils.cp_r 'examples/images/', PUBLIC_DIR.to_s
-    FileUtils.cp 'examples/release-4.0.html', "#{PUBLIC_DIR}/release-4.0.html"
-    FileUtils.cp 'examples/release-4.0.css', "#{PUBLIC_DIR}/release-4.0.css"
-    FileUtils.cp 'examples/release-4.1.html', "#{PUBLIC_DIR}/release-4.1.html"
-    FileUtils.cp 'examples/release-4.1.css', "#{PUBLIC_DIR}/release-4.1.css"
-    FileUtils.cp 'examples/a11y-dark.css', "#{PUBLIC_DIR}/a11y-dark.css"
-    FileUtils.cp 'examples/release-5.1.html', "#{PUBLIC_DIR}/release-5.1.html"
-    FileUtils.cp 'examples/release-5.1.css', "#{PUBLIC_DIR}/release-5.1.css"
-    FileUtils.cp 'examples/release-5.2.html', "#{PUBLIC_DIR}/release-5.2.html"
+
+    # Discover every examples/release-<version>.html demo (and its optional
+    # matching .css), copy it over, and collect the version for the landing page.
+    versions = Dir.glob('examples/release-*.html').filter_map do |html|
+      version = File.basename(html, '.html').delete_prefix('release-')
+      FileUtils.cp html, "#{PUBLIC_DIR}/#{File.basename(html)}"
+      css = "examples/release-#{version}.css"
+      FileUtils.cp css, "#{PUBLIC_DIR}/#{File.basename(css)}" if File.exist?(css)
+      version
+    end
+
+    extra_release_files.each { |f| FileUtils.cp f, "#{PUBLIC_DIR}/#{File.basename(f)}" }
+
+    # List releases on the landing page, most recent version first.
+    items = versions.sort_by { |v| Gem::Version.new(v) }.reverse.map do |version|
+      %(          <li><a href="./release-#{version}.html">Asciidoctor reveal.js #{version}</a></li>)
+    end.join("\n")
+
+    index = File.read('tasks/index.html').sub('{{releases}}', items)
+    File.write "#{PUBLIC_DIR}/index.html", index
   end
 end


### PR DESCRIPTION
Discover examples/release-*.html (and matching .css) automatically, copy extra shared assets via EXTRA_RELEASE_FILES, and generate index.html from a template with releases listed newest version first.