### PR TITLE
docs: add reveal.js 6.0 release demo showcasing the lightbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 ### Enhancements
 
   * Upgrade to reveal.js 6.0.1
+  * Image and video lightbox: add `data-preview-image`/`data-preview-video` (with optional `data-preview-fit`) to an image to open it full screen
   * Reimplement the converter in pure Ruby (drop the `asciidoctor-templates-compiler` Slim templates)
   * Port the converter to native Asciidoctor.js 4.0 (Node 18+, async convert handlers, validated byte-for-byte against the Ruby converter)
   * Update Asciidoctor to 4.0.0-alpha.6 and drop the workarounds that are no longer needed
@@ -18,6 +19,8 @@ For a detailed view of what has changed, refer to the [commit history](https://g
   * Bump the Volta-pinned Node.js to 24.16.0
   * Improve the Renovate configuration for smaller, scheduled pull requests
   * Automate the release process via GitHub Actions, triggered from the Actions UI with a version input
+  * Auto-discover the release demos (`examples/release-*`) when publishing the showcase site
+  * Extract shared helpers for the release scripts
   * Add a workflow to begin the next development version after a final release
   * Mark GitHub releases as pre-releases automatically for pre-release versions
   * Replace the archived `actions/create-release` and `actions/upload-release-asset` actions with the GitHub CLI

--- a/examples/release-6.0.adoc
+++ b/examples/release-6.0.adoc
@@ -1,0 +1,48 @@
+= Asciidoctor reveal.js 6.0
+:source-highlighter: highlight.js
+:highlightjs-theme: a11y-dark.css
+:highlightjs-languages: asciidoc
+:icons: font
+:imagesdir: images/
+// reveal.js config
+:customcss: release-6.0.css
+:revealjs_theme: moon
+:revealjs_hash: true
+:revealjs_width: 1080
+
+== New Features icon:rocket[set=fas]
+
+Powered by https://revealjs.com[reveal.js] 6.0
+
+== Image lightbox
+
+Click the picture to open it in a full-screen lightbox icon:hand-pointer[set=far]
+
+image::cute-cat-1.jpg[A cute cat,height="320px",data-preview-image="images/cute-cat-1.jpg"]
+
+== Fit the lightbox to the slide
+
+Use `data-preview-fit` to control how the preview is scaled.
+
+image::70s.jpg[Seventies vibe,height="320px",data-preview-image="images/70s.jpg",data-preview-fit="contain"]
+
+== Website preview
+
+Open a link in a full-screen iframe overlay icon:hand-pointer[set=far]
+
+https://docs.asciidoctor.org/[Open the Asciidoctor docs,preview=true]
+
+== Image as a website preview
+
+Click the image to preview a website icon:hand-pointer[set=far]
+
+image::asciidoctor-logo.svg[AsciiDoc website,height="220px",data-preview-link="https://asciidoc.org/"]
+
+[transition=fade,transition-speed=slow]
+== Learn More!
+
+* https://github.com/asciidoctor/asciidoctor-reveal.js/[Asciidoctor reveal.js]
+* https://revealjs.com[reveal.js]
+* https://github.com/asciidoctor/asciidoctor/[Asciidoctor]
+* https://asciidoc.org/[What is AsciiDoc?]
+* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/master/examples/release-6.0.adoc[Source of this presentation (AsciiDoc)]

--- a/examples/release-6.0.css
+++ b/examples/release-6.0.css
@@ -1,0 +1,7 @@
+h1 {
+  text-wrap: balance;
+}
+
+.reveal .imageblock img {
+  cursor: zoom-in;
+}


### PR DESCRIPTION
Add examples/release-6.0.adoc (and its stylesheet) to highlight the reveal.js 6.0 features: image lightbox via data-preview-image (with data-preview-fit) and the website preview overlay via data-preview-link. Record the lightbox enhancement and the recent showcase/release-script changes in the changelog.