### PR TITLE
chore: update remaining master references to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,7 +1,7 @@
 name: Begin next development version
 
 # Run this manually after a final release (not after a pre-release) to bump the
-# minor version and switch master back to a -dev version, e.g. 5.3.0 -> 5.4.0-dev.
+# minor version and switch main back to a -dev version, e.g. 5.3.0 -> 5.4.0-dev.
 on:
   workflow_dispatch:
 
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
       - name: Install Node
         uses: actions/setup-node@v6
@@ -30,4 +30,4 @@ jobs:
       - name: Begin next development version
         run: npm run release:next
       - name: Push
-        run: git push origin master
+        run: git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
@@ -56,7 +56,7 @@ jobs:
           npm test
       # only reached when the tests above succeed
       - name: Push release commits and tag
-        run: git push origin master --tags
+        run: git push origin main --tags
 
   publish_ruby:
     needs: prepare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 This document provides a high-level view of the changes introduced in Asciidoctor reveal.js by release.
-For a detailed view of what has changed, refer to the [commit history](https://github.com/asciidoctor/asciidoctor-reveal.js/commits/master) on GitHub.
+For a detailed view of what has changed, refer to the [commit history](https://github.com/asciidoctor/asciidoctor-reveal.js/commits/main) on GitHub.
 
-## master (unreleased)
+## main (unreleased)
 
 ### Enhancements
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ ifdef::env-github,env-browser[]
 :toclevels: 2
 endif::[]
 ifdef::env-github[]
-:branch: master
+:branch: main
 :status:
 :outfilesuffix: .adoc
 :!toc-title:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
   attributes:
     url-project-repo: 'https://github.com/asciidoctor/asciidoctor-reveal.js'
     url-asciidoctorj-revealjs: 'https://github.com/asciidoctor/asciidoctorj-reveal.js'
-    url-project-examples: 'https://github.com/asciidoctor/asciidoctor-reveal.js/tree/master/examples'
+    url-project-examples: 'https://github.com/asciidoctor/asciidoctor-reveal.js/tree/main/examples'
     url-asciidoctor: 'https://github.com/asciidoctor/asciidoctor'
     url-asciidoctorjs: 'https://github.com/asciidoctor/asciidoctor.js'
     url-revealjs-home: 'https://revealjs.com'

--- a/docs/modules/converter/pages/features.adoc
+++ b/docs/modules/converter/pages/features.adoc
@@ -46,7 +46,7 @@ There are a few ways to have no titles on slides.
 * Adding the `notitle` option to your slide
 * Adding the `conceal` option to your slide
 
-See {url-project-repo}/blob/master/examples/concealed-slide-titles.adoc[concealed-slide-titles.adoc].
+See {url-project-repo}/blob/main/examples/concealed-slide-titles.adoc[concealed-slide-titles.adoc].
 
 NOTE: `conceal` and `notitle` have the advantage that the slide still has an id so it can be linked to.
 

--- a/docs/modules/converter/pages/revealjs-options.adoc
+++ b/docs/modules/converter/pages/revealjs-options.adoc
@@ -4,7 +4,7 @@
 
 A number of document-header attributes are specific to the reveal.js converter.
 They share the names used by the reveal.js project, except that they are prefixed with `revealjs_` and the case doesn't matter.
-They are applied in the {url-project-repo}/blob/master/lib/asciidoctor_revealjs/converter.rb[converter] (see `convert_document`).
+They are applied in the {url-project-repo}/blob/main/lib/asciidoctor_revealjs/converter.rb[converter] (see `convert_document`).
 
 NOTE: The defaults match the reveal.js defaults.
 

--- a/docs/modules/converter/pages/syntax/background.adoc
+++ b/docs/modules/converter/pages/syntax/background.adoc
@@ -3,7 +3,7 @@
 == Background colors
 
 Background colors for slides can be specified by two means: a classic one and one using AsciiDoc roles.
-See {url-project-repo}/blob/master/examples/background-color.adoc[background-color.adoc] for more examples.
+See {url-project-repo}/blob/main/examples/background-color.adoc[background-color.adoc] for more examples.
 
 === Using AsciiDoc roles
 

--- a/docs/modules/project/pages/hacking.adoc
+++ b/docs/modules/project/pages/hacking.adoc
@@ -74,7 +74,7 @@ Relevant documentation: {url-asciidoctor-abstractnode-attr}
 
 == Merge / Review policy
 
-Any non-trivial change should be integrated in master via a pull-request.
+Any non-trivial change should be integrated in main via a pull-request.
 This gives the community a chance to participate and helps write better code because it encourages people to review their own patches.
 
 Pull requests should come from personal forks in order not to clutter the upstream repository.
@@ -190,7 +190,7 @@ You can get the list of all contributors using `git` (don't forget to replace `%
 ====
 
 . Make sure that the highlight plugin code embed in _lib/asciidoctor_revealjs/highlightjs.rb_ is up-to-date with the version of reveal.js
-. Make sure the changelog entry for the version you are about to release is committed and pushed to `master`.
+. Make sure the changelog entry for the version you are about to release is committed and pushed to `main`.
 
 === Release
 
@@ -204,15 +204,15 @@ See the `.github/workflows/release.yml` file for details.
 To trigger a release:
 
 . Go to the https://github.com/asciidoctor/asciidoctor-reveal.js/actions/workflows/release.yml[Release workflow] on GitHub Actions.
-. Click *Run workflow*, keep the `master` branch selected, and enter the version to release (e.g., `5.3.0` or `5.3.0-beta.1`).
+. Click *Run workflow*, keep the `main` branch selected, and enter the version to release (e.g., `5.3.0` or `5.3.0-beta.1`).
 . Click *Run workflow*.
 
 The workflow bumps the version in _package.json_ and _lib/asciidoctor_revealjs/version.rb_ and runs the tests.
-Only if the tests pass does it commit, tag (`v%version%`) and push to `master`, then publish to rubygems.org and npmjs.com and build the single executable binaries (one per platform) attached to the GitHub release.
+Only if the tests pass does it commit, tag (`v%version%`) and push to `main`, then publish to rubygems.org and npmjs.com and build the single executable binaries (one per platform) attached to the GitHub release.
 
 [NOTE]
 ====
-The `master` branch must allow the `github-actions[bot]` to push the release commits and tag.
+The `main` branch must allow the `github-actions[bot]` to push the release commits and tag.
 If branch protection rules reject the push, the release will fail at the *Push release commits and tag* step.
 ====
 
@@ -238,7 +238,7 @@ also amend `WhenBackendIsRevealJs.java` in both `tests` and `itests` folders and
 This step is optional and should only be done after a *final* release (not after a pre-release such as `5.3.0-beta.1`).
 
 Trigger the https://github.com/asciidoctor/asciidoctor-reveal.js/actions/workflows/post-release.yml[Begin next development version workflow] from GitHub Actions.
-It bumps the minor version to the next `-dev` version (e.g., `5.3.0` -> `5.4.0-dev`) in _package.json_, _lib/asciidoctor_revealjs/version.rb_ and _docs/antora.yml_, then commits and pushes to `master`.
+It bumps the minor version to the next `-dev` version (e.g., `5.3.0` -> `5.4.0-dev`) in _package.json_, _lib/asciidoctor_revealjs/version.rb_ and _docs/antora.yml_, then commits and pushes to `main`.
 
 Alternatively, you can run it locally and follow the printed instructions:
 

--- a/docs/modules/setup/pages/ruby-setup.adoc
+++ b/docs/modules/setup/pages/ruby-setup.adoc
@@ -89,6 +89,6 @@ The feature is activated with the `--template-dir` or `-T` option:
   $ bundle exec asciidoctor-revealjs -T templates presentation.adoc
 
 Any node not handled by a template provided in the directory specified on the command-line will fall back to the built-in conversion provided by your version of Asciidoctor reveal.js.
-Refer to our {url-project-repo}/blob/master/lib/asciidoctor_revealjs/converter.rb[converter^] for inspiration.
+Refer to our {url-project-repo}/blob/main/lib/asciidoctor_revealjs/converter.rb[converter^] for inspiration.
 
 This feature hasn't been ported to the JavaScript CLI (and API) or the standalone executables.

--- a/examples/release-4.0.adoc
+++ b/examples/release-4.0.adoc
@@ -189,4 +189,4 @@ Including source code!
 * https://revealjs.com[reveal.js]
 * https://github.com/asciidoctor/asciidoctor/[Asciidoctor]
 * https://asciidoctor.org/docs/what-is-asciidoc/[What is AsciiDoc?]
-* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/master/examples/release-4.0.adoc[This slide deck's AsciiDoc source]
+* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/main/examples/release-4.0.adoc[This slide deck's AsciiDoc source]

--- a/examples/release-4.1.adoc
+++ b/examples/release-4.1.adoc
@@ -130,4 +130,4 @@ Now to the right!
 * https://revealjs.com[reveal.js]
 * https://github.com/asciidoctor/asciidoctor/[Asciidoctor]
 * https://asciidoctor.org/docs/what-is-asciidoc/[What is AsciiDoc?]
-* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/master/examples/release-4.1.adoc[This slide deck's AsciiDoc source]
+* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/main/examples/release-4.1.adoc[This slide deck's AsciiDoc source]

--- a/examples/release-5.1.adoc
+++ b/examples/release-5.1.adoc
@@ -40,4 +40,4 @@
 * https://revealjs.com[reveal.js]
 * https://github.com/asciidoctor/asciidoctor/[Asciidoctor]
 * https://asciidoc.org/[What is AsciiDoc?]
-* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/master/examples/release-5.1.adoc[Source of this presentation (AsciiDoc)]
+* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/main/examples/release-5.1.adoc[Source of this presentation (AsciiDoc)]

--- a/examples/release-5.2.adoc
+++ b/examples/release-5.2.adoc
@@ -46,4 +46,4 @@ Allow synchronized fragment display
 * https://revealjs.com[reveal.js]
 * https://github.com/asciidoctor/asciidoctor/[Asciidoctor]
 * https://asciidoc.org/[What is AsciiDoc?]
-* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/master/examples/release-5.1.adoc[Source of this presentation (AsciiDoc)]
+* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/main/examples/release-5.1.adoc[Source of this presentation (AsciiDoc)]

--- a/examples/release-6.0.adoc
+++ b/examples/release-6.0.adoc
@@ -45,4 +45,4 @@ image::asciidoctor-logo.svg[AsciiDoc website,height="220px",data-preview-link="h
 * https://revealjs.com[reveal.js]
 * https://github.com/asciidoctor/asciidoctor/[Asciidoctor]
 * https://asciidoc.org/[What is AsciiDoc?]
-* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/master/examples/release-6.0.adoc[Source of this presentation (AsciiDoc)]
+* https://github.com/asciidoctor/asciidoctor-reveal.js/raw/main/examples/release-6.0.adoc[Source of this presentation (AsciiDoc)]

--- a/tasks/release/common.js
+++ b/tasks/release/common.js
@@ -38,8 +38,8 @@ export function requireVersion (script) {
   return releaseVersion
 }
 
-// Ensure the working directory is clean, and we are on the master branch or exit.
-export function ensureCleanMasterBranch (action) {
+// Ensure the working directory is clean, and we are on the main branch or exit.
+export function ensureCleanMainBranch (action) {
   try {
     childProcess.execSync('git diff-index --quiet HEAD --', { cwd: projectRootDirectory })
   } catch (e) {
@@ -48,8 +48,8 @@ export function ensureCleanMasterBranch (action) {
     process.exit(1)
   }
   const branchName = childProcess.execSync('git symbolic-ref --short HEAD', { cwd: projectRootDirectory }).toString('utf-8').trim()
-  if (branchName !== 'master') {
-    console.error(`${action} must be performed on master branch`)
+  if (branchName !== 'main') {
+    console.error(`${action} must be performed on main branch`)
     process.exit(1)
   }
 }

--- a/tasks/release/next.js
+++ b/tasks/release/next.js
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { readFileSync } from 'node:fs'
-import { projectRootDirectory, execSync, writeFile, ensureCleanMasterBranch } from './common.js'
+import { projectRootDirectory, execSync, writeFile, ensureCleanMainBranch } from './common.js'
 
 // Parse a version into its major/minor/patch numbers, ignoring any pre-release (.dev and -dev).
 const toSemVer = (version) => {
@@ -12,7 +12,7 @@ const toSemVer = (version) => {
   return { major, minor, patch }
 }
 
-ensureCleanMasterBranch('Preparing next version')
+ensureCleanMainBranch('Preparing next version')
 
 // read current version from package.json
 const pkgPath = path.join(projectRootDirectory, 'package.json')
@@ -42,7 +42,7 @@ writeFile(antoraYmlPath, antoraYmlContent.replace(/version: '([^']+)'/, `version
 execSync(`git commit -a -m "Begin development on next release ${nextVersion}"`, { cwd: projectRootDirectory })
 
 console.info('To complete, you need to:')
-console.info('[ ] push changes upstream: `git push origin master`')
+console.info('[ ] push changes upstream: `git push origin main`')
 console.info(`[ ] create a branch from the latest tag: \`git checkout -b maint-${currentSemVer.major}.${currentSemVer.minor}.x v${currentVersion}\``)
 console.info(`[ ] push the maintenance branch: \`git push origin maint-${currentSemVer.major}.${currentSemVer.minor}.x\``)
 console.info(`[ ] update Antora playbook to add this branch: https://github.com/asciidoctor/docs.asciidoctor.org/edit/main/antora-playbook.yml`)

--- a/tasks/release/prepare.js
+++ b/tasks/release/prepare.js
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { readFileSync } from 'node:fs'
 import process from 'node:process'
-import { projectRootDirectory, execSync, writeFile, requireVersion, ensureCleanMasterBranch } from './common.js'
+import { projectRootDirectory, execSync, writeFile, requireVersion, ensureCleanMainBranch } from './common.js'
 
 const PRERELEASE_VERSION_RX = /(?<version>[0-9]+\.[0-9]+\.[0-9]+)(?<preversion>-[a-z]+\.[0-9]+)?/
 
@@ -10,7 +10,7 @@ console.log(`Release version: ${releaseVersion}`)
 if (process.env.DRY_RUN) {
   console.warn('Dry run! To perform the release, run the command again without DRY_RUN environment variable')
 }
-ensureCleanMasterBranch('Release')
+ensureCleanMainBranch('Release')
 
 // update version in package.json
 const pkgPath = path.join(projectRootDirectory, 'package.json')
@@ -37,4 +37,4 @@ execSync(`git commit --allow-empty -m "Release ${releaseVersion}"`, { cwd: proje
 execSync(`git tag v${releaseVersion} -m "Version ${releaseVersion}"`, { cwd: projectRootDirectory })
 
 console.info('To complete the release, you need to:')
-console.info('[ ] push changes upstream: `git push origin master --tags`')
+console.info('[ ] push changes upstream: `git push origin main --tags`')


### PR DESCRIPTION
The default branch was renamed to main on GitHub; the release workflows,
release scripts, and doc links still pointed at master.The default branch was renamed to main on GitHub; the release workflows, release scripts, and doc links still pointed at master.