### PR TITLE
fix: stop dropping arbitrary data-* attributes on sections and the title slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 
 ### Bug Fixes
 
+  * Stop dropping arbitrary `data-*` attributes set on a section or the title slide (Ruby and JS converters); previously only a fixed allowlist of `data-*` attributes (`data-background-*`, `data-transition`, `data-state`, `data-auto-animate-*`, ...) was rendered on the generated `<section>` element, which prevented using reveal.js plugins that rely on their own custom `data-*` attributes (#541)
   * Resync the embedded highlight.js plugin (`data/highlight-plugin.js`) with reveal.js 6.0.1; it was still the 4.1.2 version, which threw a `ReferenceError` (undefined `Plugin`) whenever a code block had more than one highlight step
   * Remove the dead `convert_stretch_nested_elements` method in the Ruby converter, which called a non-existent `RevealJsOptions.stretch_nested_elements_script` method; it was never dispatched (no node has the `stretch_nested_elements` node name), so the bug was latent
   * Fix the `asciidoctor-revealjs` Ruby CLI, which crashed with `LoadError: cannot load such file -- asciidoctor-revealjs` on every invocation; it required the hyphenated `asciidoctor-revealjs` instead of the actual `asciidoctor_revealjs` file/gem name

--- a/js/src/converter.js
+++ b/js/src/converter.js
@@ -85,6 +85,16 @@ function dataAttrs (nodeAttributes) {
   return result
 }
 
+// Merges arbitrary data- attributes from a node's attributes into a set of
+// already computed/known attributes, without letting the passthrough values
+// clobber the known ones (e.g. data-background-color computed from the
+// `background-color` shorthand attribute).
+function mergeKnownDataAttrs (known, nodeAttributes) {
+  const passthrough = dataAttrs(nodeAttributes)
+  for (const key of Object.keys(known)) delete passthrough[key]
+  return { ...known, ...passthrough }
+}
+
 // Whether the node should carry the reveal.js `fragment` class because it is
 // part of a step. Variant used by most block elements.
 function step (node) {
@@ -293,7 +303,7 @@ export default class RevealJsConverter extends ConverterBase {
   async convert_title_slide (node) {
     const bgImage = node.hasAttribute('title-slide-background-image') ? await node.imageUri(node.getAttribute('title-slide-background-image')) : null
     const bgVideo = node.hasAttribute('title-slide-background-video') ? node.mediaUri(node.getAttribute('title-slide-background-video')) : null
-    const attrs = attributes({
+    const attrs = attributes(mergeKnownDataAttrs({
       class: ['title', node.getRole()],
       'data-state': 'title',
       'data-transition': node.getAttribute('title-slide-transition'),
@@ -310,7 +320,7 @@ export default class RevealJsConverter extends ConverterBase {
       'data-background-repeat': node.getAttribute('title-slide-background-repeat'),
       'data-background-position': node.getAttribute('title-slide-background-position'),
       'data-background-transition': node.getAttribute('title-slide-background-transition')
-    })
+    }, node.getAttributes()))
     let buf = ''
     const titleObj = node.doctitle({ partition: true, use_fallback: true })
     if (titleObj.hasSubtitle()) {
@@ -382,7 +392,7 @@ export default class RevealJsConverter extends ConverterBase {
     }
 
     const section = async () => {
-      const attrs = attributes({
+      const attrs = attributes(mergeKnownDataAttrs({
         id: titleless ? null : node.getId(),
         class: node.getRoles(),
         'data-background-gradient': node.getAttribute('background-gradient'),
@@ -407,7 +417,7 @@ export default class RevealJsConverter extends ConverterBase {
         'data-auto-animate-duration': node.getAttribute('auto-animate-duration') || node.hasOption('auto-animate-duration'),
         'data-auto-animate-id': node.getAttribute('auto-animate-id'),
         'data-auto-animate-restart': node.hasAttribute('auto-animate-restart') || node.hasOption('auto-animate-restart')
-      })
+      }, node.getAttributes()))
       let inner = ''
       if (!hideTitle) inner += `<h2>${sectionTitle(node)}</h2>`
       if (parentSectionWithVerticalSlides) {

--- a/lib/asciidoctor_revealjs/converter.rb
+++ b/lib/asciidoctor_revealjs/converter.rb
@@ -567,31 +567,31 @@ module Asciidoctor
 
         section = lambda do
           attrs = attributes({
-                               :id => (titleless ? nil : node.id),
-                               :class => node.roles,
-                               'data-background-gradient' => (node.attr 'background-gradient'),
-                               'data-transition' => (node.attr 'transition'),
-                               'data-transition-speed' => (node.attr 'transition-speed'),
-                               'data-background-color' => data_background_color,
-                               'data-background-image' => data_background_image,
-                               'data-background-size' => data_background_size || node.attr('background-size'),
-                               'data-background-repeat' => data_background_repeat || node.attr('background-repeat'),
-                               'data-background-transition' => data_background_transition || node.attr('background-transition'),
-                               'data-background-position' => data_background_position || node.attr('background-position'),
-                               'data-background-iframe' => (node.attr 'background-iframe'),
-                               'data-background-video' => data_background_video,
-                               'data-background-video-loop' => (node.attr? 'background-video-loop') || (node.option? 'loop'),
-                               'data-background-video-muted' => (node.attr? 'background-video-muted') || (node.option? 'muted'),
-                               'data-background-opacity' => (node.attr 'background-opacity'),
-                               'data-autoslide' => (node.attr 'autoslide'),
-                               'data-state' => (node.attr 'state'),
-                               'data-auto-animate' => (node.attr? 'auto-animate') || (node.option? 'auto-animate'),
-                               'data-auto-animate-easing' => (node.attr 'auto-animate-easing') || (node.option? 'auto-animate-easing'),
-                               'data-auto-animate-unmatched' => (node.attr 'auto-animate-unmatched') || (node.option? 'auto-animate-unmatched'),
-                               'data-auto-animate-duration' => (node.attr 'auto-animate-duration') || (node.option? 'auto-animate-duration'),
-                               'data-auto-animate-id' => (node.attr 'auto-animate-id'),
-                               'data-auto-animate-restart' => (node.attr? 'auto-animate-restart') || (node.option? 'auto-animate-restart')
-                             })
+            :id => (titleless ? nil : node.id),
+            :class => node.roles,
+            'data-background-gradient' => (node.attr 'background-gradient'),
+            'data-transition' => (node.attr 'transition'),
+            'data-transition-speed' => (node.attr 'transition-speed'),
+            'data-background-color' => data_background_color,
+            'data-background-image' => data_background_image,
+            'data-background-size' => data_background_size || node.attr('background-size'),
+            'data-background-repeat' => data_background_repeat || node.attr('background-repeat'),
+            'data-background-transition' => data_background_transition || node.attr('background-transition'),
+            'data-background-position' => data_background_position || node.attr('background-position'),
+            'data-background-iframe' => (node.attr 'background-iframe'),
+            'data-background-video' => data_background_video,
+            'data-background-video-loop' => (node.attr? 'background-video-loop') || (node.option? 'loop'),
+            'data-background-video-muted' => (node.attr? 'background-video-muted') || (node.option? 'muted'),
+            'data-background-opacity' => (node.attr 'background-opacity'),
+            'data-autoslide' => (node.attr 'autoslide'),
+            'data-state' => (node.attr 'state'),
+            'data-auto-animate' => (node.attr? 'auto-animate') || (node.option? 'auto-animate'),
+            'data-auto-animate-easing' => (node.attr 'auto-animate-easing') || (node.option? 'auto-animate-easing'),
+            'data-auto-animate-unmatched' => (node.attr 'auto-animate-unmatched') || (node.option? 'auto-animate-unmatched'),
+            'data-auto-animate-duration' => (node.attr 'auto-animate-duration') || (node.option? 'auto-animate-duration'),
+            'data-auto-animate-id' => (node.attr 'auto-animate-id'),
+            'data-auto-animate-restart' => (node.attr? 'auto-animate-restart') || (node.option? 'auto-animate-restart')
+          }.merge(data_attrs(node.attributes)) { |_key, known_value, _passthrough_value| known_value })
           inner = +''
           inner << %(<h2>#{section_title node}</h2>) unless hide_title
           if parent_section_with_vertical_slides
@@ -714,23 +714,23 @@ module Asciidoctor
         bg_image = node.attr?('title-slide-background-image') ? node.image_uri(node.attr('title-slide-background-image')) : nil
         bg_video = node.attr?('title-slide-background-video') ? node.media_uri(node.attr('title-slide-background-video')) : nil
         attrs = attributes({
-                             :class => ['title', node.role],
-                             'data-state' => 'title',
-                             'data-transition' => (node.attr 'title-slide-transition'),
-                             'data-transition-speed' => (node.attr 'title-slide-transition-speed'),
-                             'data-background' => (node.attr 'title-slide-background'),
-                             'data-background-size' => (node.attr 'title-slide-background-size'),
-                             'data-background-image' => bg_image,
-                             'data-background-video' => bg_video,
-                             'data-background-video-loop' => (node.attr 'title-slide-background-video-loop'),
-                             'data-background-video-muted' => (node.attr 'title-slide-background-video-muted'),
-                             'data-background-opacity' => (node.attr 'title-slide-background-opacity'),
-                             'data-background-iframe' => (node.attr 'title-slide-background-iframe'),
-                             'data-background-color' => (node.attr 'title-slide-background-color'),
-                             'data-background-repeat' => (node.attr 'title-slide-background-repeat'),
-                             'data-background-position' => (node.attr 'title-slide-background-position'),
-                             'data-background-transition' => (node.attr 'title-slide-background-transition')
-                           })
+          :class => ['title', node.role],
+          'data-state' => 'title',
+          'data-transition' => (node.attr 'title-slide-transition'),
+          'data-transition-speed' => (node.attr 'title-slide-transition-speed'),
+          'data-background' => (node.attr 'title-slide-background'),
+          'data-background-size' => (node.attr 'title-slide-background-size'),
+          'data-background-image' => bg_image,
+          'data-background-video' => bg_video,
+          'data-background-video-loop' => (node.attr 'title-slide-background-video-loop'),
+          'data-background-video-muted' => (node.attr 'title-slide-background-video-muted'),
+          'data-background-opacity' => (node.attr 'title-slide-background-opacity'),
+          'data-background-iframe' => (node.attr 'title-slide-background-iframe'),
+          'data-background-color' => (node.attr 'title-slide-background-color'),
+          'data-background-repeat' => (node.attr 'title-slide-background-repeat'),
+          'data-background-position' => (node.attr 'title-slide-background-position'),
+          'data-background-transition' => (node.attr 'title-slide-background-transition')
+        }.merge(data_attrs(node.attributes)) { |_key, known_value, _passthrough_value| known_value })
         buf = +''
         buf << if (title_obj = node.doctitle partition: true, use_fallback: true).subtitle?
                  %(<h1>#{slice_text node, title_obj.title, (header_slice = node.header.option? :slice)}</h1><h2>#{slice_text node, title_obj.subtitle, header_slice}</h2>)

--- a/test/expected/standalone/data-attributes.html
+++ b/test/expected/standalone/data-attributes.html
@@ -1,4 +1,4 @@
-<div class="slides"><section class="title" data-state="title"><h1>Data attributes</h1></section><section id="_reference"><h2>Reference</h2><div class="slide-content"><div class="paragraph"><p><a href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes" class="bare">https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes</a></p></div></div></section>
+<div class="slides"><section class="title" data-state="title" data-custom-attribute="enabled"><h1>Data attributes</h1></section><section id="_reference"><h2>Reference</h2><div class="slide-content"><div class="paragraph"><p><a href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes" class="bare">https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes</a></p></div></div></section>
 <section id="_paragraphs"><h2>Paragraphs</h2><div class="slide-content"><div class="paragraph fragment highlight-blue" data-fragment-index="0"><p>blue</p></div>
 <div class="paragraph fragment" data-fragment-index="1"><p>white</p></div>
 <div class="paragraph fragment highlight-red" data-fragment-index="0"><p>red</p></div></div></section>
@@ -52,4 +52,6 @@ on little cat feet.</pre><div class="attribution"><cite>two lines from the poem 
 <div class="paragraph"><p>Type the word <span class="userinput">asciidoc</span> into the search bar.</p></div>
 <div class="paragraph"><p>Word with an <span id="bookmark-a">explicit</span> id.</p></div>
 <div class="paragraph"><p>Let’s put some <em id="bookmark-b" class="concept word">emphasis</em>.</p></div></div></section>
-<section id="_sidebar"><h2>Sidebar</h2><div class="slide-content"><div class="sidebarblock" data-visiblity="visible" data-position="left"><div class="content"><div class="paragraph"><p>Sidebars are used to visually separate auxiliary bits of content that supplement the main text.</p></div></div></div></div></section></div>
+<section id="_sidebar"><h2>Sidebar</h2><div class="slide-content"><div class="sidebarblock" data-visiblity="visible" data-position="left"><div class="content"><div class="paragraph"><p>Sidebars are used to visually separate auxiliary bits of content that supplement the main text.</p></div></div></div></div></section>
+<section id="_section_with_custom_data_attributes" data-my-plugin="enabled" data-foo="bar"><h2>Section with custom data attributes</h2><div class="slide-content"><div class="paragraph"><p>Arbitrary <code>data-*</code> attributes set directly on a section are preserved on the
+generated <code>&lt;section&gt;</code> element, e.g. for third-party reveal.js plugins.</p></div></div></section></div>

--- a/test/fixtures/standalone/data-attributes.adoc
+++ b/test/fixtures/standalone/data-attributes.adoc
@@ -6,6 +6,7 @@
 :source-highlighter: highlight.js
 :revealjs_hash: true
 :experimental:
+:data-custom-attribute: enabled
 
 == Reference
 
@@ -243,3 +244,9 @@ Let's put some [#bookmark-b.concept.word]_emphasis_.
 ****
 Sidebars are used to visually separate auxiliary bits of content that supplement the main text.
 ****
+
+[data-my-plugin=enabled,data-foo=bar]
+== Section with custom data attributes
+
+Arbitrary `data-*` attributes set directly on a section are preserved on the
+generated `<section>` element, e.g. for third-party reveal.js plugins.


### PR DESCRIPTION
`convert_section`/`convert_title_slide` (both the Ruby and JS converters) only rendered a fixed allowlist of `data-*` attributes (`data-background-*`, `data-transition`, `data-state`, `data-auto-animate-*`, ...), silently dropping any other `data-*` attribute set on a section or in the document header — unlike every other block converter, which already passes through arbitrary `data-*` attributes via `data_attrs()`/`dataAttrs()`. This prevented using reveal.js plugins that rely on their own custom `data-*` attributes.

Both converters now merge in the passthrough `data-*` attributes the same way other block types do, while keeping already-computed known values (e.g. `data-background-color` derived from the `background-color` shorthand) from being clobbered by a same-named passthrough attribute.

Added a regression case to `test/fixtures/standalone/data-attributes.adoc` (a document-header `data-*` attribute reflected on the title slide, and a section-level `[data-my-plugin=...,data-foo=...]` block attribute reflected on its `<section>`), verified against both the Ruby and JS converters.

Fixes #541
