### PR TITLE
fix: honor the :notitle: document attribute (hide the title slide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 
 ### Bug Fixes
 
-  * Stop dropping arbitrary `data-*` attributes set on a section or the title slide (Ruby and JS converters); previously only a fixed allowlist of `data-*` attributes (`data-background-*`, `data-transition`, `data-state`, `data-auto-animate-*`, ...) was rendered on the generated `<section>` element, which prevented using reveal.js plugins that rely on their own custom `data-*` attributes (#541)
+  * Honor the `:notitle:` document attribute (Ruby and JS converters); `convert_document` always rendered the title slide whenever the document had a header, regardless of `:notitle:` — every other title-related check (`[%notitle]` on a section, the embedded converter's own `<h1>`) already respected it, only the title slide dispatch didn't (#535)
   * Resync the embedded highlight.js plugin (`data/highlight-plugin.js`) with reveal.js 6.0.1; it was still the 4.1.2 version, which threw a `ReferenceError` (undefined `Plugin`) whenever a code block had more than one highlight step
   * Remove the dead `convert_stretch_nested_elements` method in the Ruby converter, which called a non-existent `RevealJsOptions.stretch_nested_elements_script` method; it was never dispatched (no node has the `stretch_nested_elements` node name), so the bug was latent
   * Fix the `asciidoctor-revealjs` Ruby CLI, which crashed with `LoadError: cannot load such file -- asciidoctor-revealjs` on every invocation; it required the hyphenated `asciidoctor-revealjs` instead of the actual `asciidoctor_revealjs` file/gem name

--- a/js/src/converter.js
+++ b/js/src/converter.js
@@ -212,7 +212,7 @@ export default class RevealJsConverter extends ConverterBase {
       if (!node.isNoheader()) {
         const headerDocinfo = await node.docinfo('header', '-revealjs.html')
         if (headerDocinfo) buf += headerDocinfo
-        if (node.hasHeader()) buf += await this.convert(node, 'title_slide')
+        if (node.hasHeader() && !node.isNotitle()) buf += await this.convert(node, 'title_slide')
       }
       buf += slidesContent ?? ''
       const footerDocinfo = await node.docinfo('footer', '-revealjs.html')

--- a/lib/asciidoctor_revealjs/converter.rb
+++ b/lib/asciidoctor_revealjs/converter.rb
@@ -862,7 +862,7 @@ module Asciidoctor
             unless (header_docinfo = node.docinfo :header, '-revealjs.html').empty?
               buf << header_docinfo.to_s
             end
-            buf << convert(node, 'title_slide') if node.header?
+            buf << convert(node, 'title_slide') if node.header? && !node.notitle
           end
           buf << slides_content.to_s
           unless (footer_docinfo = node.docinfo :footer, '-revealjs.html').empty?

--- a/test/expected/standalone/notitle-document.html
+++ b/test/expected/standalone/notitle-document.html
@@ -1,0 +1,1 @@
+<div class="slides"><section id="_slide_one"><h2>Slide one</h2><div class="slide-content"><div class="paragraph"><p>Content</p></div></div></section></div>

--- a/test/fixtures/standalone/notitle-document.adoc
+++ b/test/fixtures/standalone/notitle-document.adoc
@@ -1,0 +1,10 @@
+// .notitle-document
+// The document-level :notitle: attribute should hide the title slide entirely
+// :include: //div[@class="slides"]
+// :header_footer:
+= This Title Should Not Be Shown
+:notitle:
+
+== Slide one
+
+Content

--- a/test/fixtures/standalone/notitle-document.config.json
+++ b/test/fixtures/standalone/notitle-document.config.json
@@ -1,0 +1,5 @@
+{
+  "select": [
+    "div.slides"
+  ]
+}


### PR DESCRIPTION
convert_document (Ruby and JS) always rendered the title slide whenever the document had a header, regardless of the `:notitle:` document attribute. Every other title-related check in the converters (`[%notitle]` on a section, the embedded converter's own `<h1>`) already respected `notitle`/`isNotitle`; only the title slide dispatch didn't.

Guard the `title_slide` conversion with the same check so setting `:notitle:` on the document hides the title slide entirely, as it does for the embedded converter.

Fixes #535