### PR TITLE
fix: show checklist checkboxes when :icons: font is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 ### Bug Fixes
 
   * Honor the `:notitle:` document attribute (Ruby and JS converters); `convert_document` always rendered the title slide whenever the document had a header, regardless of `:notitle:` — every other title-related check (`[%notitle]` on a section, the embedded converter's own `<h1>`) already respected it, only the title slide dispatch didn't (#535)
+  * Fix checklist checkboxes being invisible when `:icons: font` is set (Ruby and JS converters); the checked/unchecked markers used the Font Awesome 3 class names (`icon-check`/`icon-check-empty`), which don't exist in Font Awesome 4/5/6 — replaced with the same `fa fa-check-square-o`/`fa fa-square-o` classes Asciidoctor's own html5 converter uses (#526)
   * Resync the embedded highlight.js plugin (`data/highlight-plugin.js`) with reveal.js 6.0.1; it was still the 4.1.2 version, which threw a `ReferenceError` (undefined `Plugin`) whenever a code block had more than one highlight step
   * Remove the dead `convert_stretch_nested_elements` method in the Ruby converter, which called a non-existent `RevealJsOptions.stretch_nested_elements_script` method; it was never dispatched (no node has the `stretch_nested_elements` node name), so the bug was latent
   * Fix the `asciidoctor-revealjs` Ruby CLI, which crashed with `LoadError: cannot load such file -- asciidoctor-revealjs` on every invocation; it required the hyphenated `asciidoctor-revealjs` instead of the actual `asciidoctor_revealjs` file/gem name

--- a/js/src/converter.js
+++ b/js/src/converter.js
@@ -490,8 +490,8 @@ export default class RevealJsConverter extends ConverterBase {
         markerChecked = '<input type="checkbox" data-item-complete="1" checked>'
         markerUnchecked = '<input type="checkbox" data-item-complete="0">'
       } else if (node.getDocument().hasAttribute('icons', 'font')) {
-        markerChecked = '<i class="icon-check"></i>'
-        markerUnchecked = '<i class="icon-check-empty"></i>'
+        markerChecked = '<i class="fa fa-check-square-o"></i>'
+        markerUnchecked = '<i class="fa fa-square-o"></i>'
       } else {
         // could use &#9745 (checked ballot) and &#9744 (ballot) w/o font instead
         markerChecked = '<input type="checkbox" data-item-complete="1" checked disabled>'

--- a/lib/asciidoctor_revealjs/converter.rb
+++ b/lib/asciidoctor_revealjs/converter.rb
@@ -755,8 +755,8 @@ module Asciidoctor
             marker_checked = '<input type="checkbox" data-item-complete="1" checked>'
             marker_unchecked = '<input type="checkbox" data-item-complete="0">'
           elsif node.document.attr? :icons, 'font'
-            marker_checked = '<i class="icon-check"></i>'
-            marker_unchecked = '<i class="icon-check-empty"></i>'
+            marker_checked = '<i class="fa fa-check-square-o"></i>'
+            marker_unchecked = '<i class="fa fa-square-o"></i>'
           else
             # could use &#9745 (checked ballot) and &#9744 (ballot) w/o font instead
             marker_checked = '<input type="checkbox" data-item-complete="1" checked disabled>'

--- a/test/expected/standalone/font-awesome.html
+++ b/test/expected/standalone/font-awesome.html
@@ -12,4 +12,5 @@
 <section id="_added_in_5_15_0"><h2>Added in 5.15.0</h2><div class="slide-content"><div class="paragraph"><p><span class="icon"><i class="fa fa-vest fa-2x"></i></span></p></div></div></section>
 <section id="_sets"><h2>Sets</h2><div class="slide-content"><div class="paragraph"><div class="title">Brand</div><p><span class="icon"><i class="fab fa-creative-commons fa-2x"></i></span></p></div>
 <div class="paragraph"><div class="title">Regular</div><p><span class="icon"><i class="far fa-address-book fa-2x"></i></span></p></div>
-<div class="paragraph"><div class="title">Solid</div><p><span class="icon"><i class="fas fa-address-book fa-2x"></i></span></p></div></div></section></div>
+<div class="paragraph"><div class="title">Solid</div><p><span class="icon"><i class="fas fa-address-book fa-2x"></i></span></p></div></div></section>
+<section id="_checklist"><h2>Checklist</h2><div class="slide-content"><div class="ulist checklist"><ul class="checklist"><li><p><i class="fa fa-check-square-o"></i>checked</p></li><li><p><i class="fa fa-square-o"></i>not checked</p></li><li><p>normal list item</p></li></ul></div></div></section></div>

--- a/test/fixtures/standalone/font-awesome.adoc
+++ b/test/fixtures/standalone/font-awesome.adoc
@@ -41,3 +41,9 @@ icon:address-book[size=2x,set=far]
 
 .Solid
 icon:address-book[size=2x,set=fas]
+
+== Checklist
+
+* [x] checked
+* [ ] not checked
+* normal list item


### PR DESCRIPTION
convert_ulist's checklist branch for `:icons: font` rendered `<i class="icon-check"></i>/<i class="icon-check-empty"></i>`, Font Awesome 3 class names that don't exist in Font Awesome 4/5/6 (the only versions this converter's docinfo actually loads), so the checkbox icon was invisible - only the interactive (real `<input type=checkbox>`) and disabled-input variants worked.

Use the same fa fa-check-square-o/fa fa-square-o classes Asciidoctor's own html5 converter uses for the same feature, and that this converter already relies on elsewhere for icons (icon_mapping in `convert_admonition`), matching the Font Awesome 4-compatible class names shimmed by the v4-shims.min.css this converter loads alongside Font Awesome 5.

Fixes #526