### PR TITLE
docs: clarify custom-styles.adoc and fix a stale highlight.js theme default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ For a detailed view of what has changed, refer to the [commit history](https://g
 
 ### Documentation
 
+  * Clarify the Custom Styles doc page: `:customcss:` (and its `asciidoctor-revealjs.css` fallback) names a file the converter only links to, it never generates it — you have to author it yourself; also add a `revealjs_theme` vs. `revealjs_customtheme` vs. `customcss` comparison (pick a built-in theme vs. replace the theme entirely vs. layer extra overrides on top) (#513, #133)
+  * Fix the documented default highlight.js theme (`revealjs-options.adoc` said the built-in [path]_lib/css/zenburn.css_, a leftover from the pre-pure-Ruby Slim templates; the actual default is reveal.js's own bundled [path]_dist/plugin/highlight/monokai.css_)
   * Fix two dead links to example presentations (`revealjs-plugins.adoc`'s doc page pointed at a file that never existed at that path; the roles page had the same stale pattern) by linking every example a doc page cites through an Antora `attachment$` resource (`docs/modules/converter/attachments/`, symlinked to the actual file under `test/fixtures/standalone/`) instead of a hand-typed `examples/` path or GitHub blob URL
 
 ### Build

--- a/docs/modules/converter/pages/custom-styles.adoc
+++ b/docs/modules/converter/pages/custom-styles.adoc
@@ -3,12 +3,22 @@
 [[customcss]]
 == CSS Override
 
-If you use the `:customcss:` document attribute, a CSS file of the name given in the attribute is added to the list of CSS resources loaded by the rendered HTML.
-Doing so, you can then override specific elements of your theme per presentation.
+If you use the `:customcss:` document attribute, a `<link>` to the CSS file named by the attribute is added to the rendered HTML, alongside whichever theme is already active (see xref:revealjs-options.adoc[] for `:revealjs_theme:`/`:revealjs_customtheme:`).
+This lets you override specific elements of that theme on a per-presentation basis, without having to author a full theme.
+
+WARNING: The converter only links to this file; it does not generate it.
+You need to create the CSS file yourself, alongside your AsciiDoc document, with the filename you gave the `:customcss:` attribute (or the default one, see below, if you left the attribute empty).
 
 For example, to do proper position-independent text placement of a title slide with a specific background you can use:
 
-[source, css]
+.presentation.adoc
+[source,asciidoc]
+----
+:customcss: my-styles.css
+----
+
+.my-styles.css
+[source,css]
 ----
 .reveal section.title h1 {
     margin-top: 2.3em;
@@ -21,5 +31,14 @@ For example, to do proper position-independent text placement of a title slide w
 }
 ----
 
-If the `:customcss:` attribute value is empty then `asciidoctor-revealjs.css` is the CSS resource that the presentation is linked to.
+If the `:customcss:` attribute is set with an empty value (`:customcss:`, no filename), the converter falls back to a conventional filename, `asciidoctor-revealjs.css`, sitting alongside your document.
+It's still a file *you* need to provide — the converter never creates it for you, empty value or not.
+
+== `revealjs_theme` vs. `revealjs_customtheme` vs. `customcss`
+
+These three attributes all affect a presentation's appearance, but at different levels:
+
+`:revealjs_theme:`:: Selects one of reveal.js's own link:{url-revealjs-doc}/themes/[built-in themes] (`black`, `white`, `league`, ...) — a complete, ready-made stylesheet reveal.js ships with. See xref:revealjs-options.adoc[].
+`:revealjs_customtheme:`:: *Replaces* the theme stylesheet entirely with a file or URL of your own, instead of picking one of the built-in themes. Use this when you're authoring (or reusing) a full theme, not just tweaking one. See xref:revealjs-options.adoc[].
+`:customcss:`:: *Adds* an extra stylesheet on top of whichever theme is active (built-in or custom), loaded after it. Use this for small, presentation-specific overrides — you don't need a whole theme just to change a heading's margin.
 

--- a/docs/modules/converter/pages/revealjs-options.adoc
+++ b/docs/modules/converter/pages/revealjs-options.adoc
@@ -24,7 +24,7 @@ Default is disabled.
 |:highlightjs-theme:
 |<file\|URL>
 |Overrides {url-highlightjs}[highlight.js^] CSS style with given file or URL.
-Default is built-in [path]_lib/css/zenburn.css_.
+Default is reveal.js`' own bundled [path]_dist/plugin/highlight/monokai.css_.
 
 |:revealjsdir:
 |<file\|URL>


### PR DESCRIPTION
- State explicitly that :customcss: (and its asciidoctor-revealjs.css fallback) names a file the converter only links to - it never generates one, the reader has to author it themselves. That wasn't said anywhere, so anyone who forgot to create the file just saw no effect with no explanation why.
- Add a revealjs_theme vs. revealjs_customtheme vs. customcss comparison: pick a built-in theme vs. replace the theme entirely vs. layer small overrides on top of whichever theme is active. The three attributes were only ever documented in isolation.
- Fix the documented default highlight.js theme in revealjs-options.adoc: it still said the built-in lib/css/zenburn.css, a leftover from the pre-pure-Ruby Slim templates; the actual default is reveal.js's own bundled dist/plugin/highlight/monokai.css.

Fixes #513, #133